### PR TITLE
feat: add license tags

### DIFF
--- a/data/licenses/0BSD.json
+++ b/data/licenses/0BSD.json
@@ -43,5 +43,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:public-domain",
+    "copyleft:none",
+    "domain:content",
+    "domain:data"
   ]
 }

--- a/data/licenses/3D-Slicer-1.0.json
+++ b/data/licenses/3D-Slicer-1.0.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AAL.json
+++ b/data/licenses/AAL.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ADSL.json
+++ b/data/licenses/ADSL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AFL-1.1.json
+++ b/data/licenses/AFL-1.1.json
@@ -41,5 +41,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AFL-1.2.json
+++ b/data/licenses/AFL-1.2.json
@@ -41,5 +41,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AFL-2.0.json
+++ b/data/licenses/AFL-2.0.json
@@ -29,5 +29,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AFL-2.1.json
+++ b/data/licenses/AFL-2.1.json
@@ -29,5 +29,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AFL-3.0.json
+++ b/data/licenses/AFL-3.0.json
@@ -52,5 +52,11 @@
     "trademark-use",
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/AGPL-1.0-only.json
+++ b/data/licenses/AGPL-1.0-only.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
+  ]
 }

--- a/data/licenses/AGPL-1.0-or-later.json
+++ b/data/licenses/AGPL-1.0-or-later.json
@@ -27,5 +27,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
+  ]
 }

--- a/data/licenses/AGPL-1.0.json
+++ b/data/licenses/AGPL-1.0.json
@@ -29,5 +29,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
+  ]
 }

--- a/data/licenses/AGPL-3.0-only.json
+++ b/data/licenses/AGPL-3.0-only.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
+  ]
 }

--- a/data/licenses/AGPL-3.0-or-later.json
+++ b/data/licenses/AGPL-3.0-or-later.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
+  ]
 }

--- a/data/licenses/AGPL-3.0.json
+++ b/data/licenses/AGPL-3.0.json
@@ -55,5 +55,14 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:AGPL",
+    "domain:software",
+    "copyleft:network"
   ]
 }

--- a/data/licenses/AMD-newlib.json
+++ b/data/licenses/AMD-newlib.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AMDPLPA.json
+++ b/data/licenses/AMDPLPA.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AML-glslang.json
+++ b/data/licenses/AML-glslang.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AML.json
+++ b/data/licenses/AML.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AMPAS.json
+++ b/data/licenses/AMPAS.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ANTLR-PD-fallback.json
+++ b/data/licenses/ANTLR-PD-fallback.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ANTLR-PD.json
+++ b/data/licenses/ANTLR-PD.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APAFML.json
+++ b/data/licenses/APAFML.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APL-1.0.json
+++ b/data/licenses/APL-1.0.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APSL-1.0.json
+++ b/data/licenses/APSL-1.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APSL-1.1.json
+++ b/data/licenses/APSL-1.1.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APSL-1.2.json
+++ b/data/licenses/APSL-1.2.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/APSL-2.0.json
+++ b/data/licenses/APSL-2.0.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ASWF-Digital-Assets-1.0.json
+++ b/data/licenses/ASWF-Digital-Assets-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ASWF-Digital-Assets-1.1.json
+++ b/data/licenses/ASWF-Digital-Assets-1.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Abstyles.json
+++ b/data/licenses/Abstyles.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/AdaCore-doc.json
+++ b/data/licenses/AdaCore-doc.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Adobe-2006.json
+++ b/data/licenses/Adobe-2006.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Adobe-Display-PostScript.json
+++ b/data/licenses/Adobe-Display-PostScript.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Adobe-Glyph.json
+++ b/data/licenses/Adobe-Glyph.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Adobe-Utopia.json
+++ b/data/licenses/Adobe-Utopia.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Afmparse.json
+++ b/data/licenses/Afmparse.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Aladdin.json
+++ b/data/licenses/Aladdin.json
@@ -28,5 +28,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Apache-1.0.json
+++ b/data/licenses/Apache-1.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/Apache-1.1.json
+++ b/data/licenses/Apache-1.1.json
@@ -38,5 +38,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/Apache-2.0.json
+++ b/data/licenses/Apache-2.0.json
@@ -64,5 +64,12 @@
     "trademark-use",
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/App-s2p.json
+++ b/data/licenses/App-s2p.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Arphic-1999.json
+++ b/data/licenses/Arphic-1999.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Artistic-1.0-Perl.json
+++ b/data/licenses/Artistic-1.0-Perl.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Artistic-1.0-cl8.json
+++ b/data/licenses/Artistic-1.0-cl8.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Artistic-1.0.json
+++ b/data/licenses/Artistic-1.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Artistic-2.0.json
+++ b/data/licenses/Artistic-2.0.json
@@ -61,5 +61,11 @@
     "liability",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/Artistic-dist.json
+++ b/data/licenses/Artistic-dist.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Aspell-RU.json
+++ b/data/licenses/Aspell-RU.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/BSD-1-Clause.json
+++ b/data/licenses/BSD-1-Clause.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-Darwin.json
+++ b/data/licenses/BSD-2-Clause-Darwin.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-FreeBSD.json
+++ b/data/licenses/BSD-2-Clause-FreeBSD.json
@@ -29,5 +29,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-NetBSD.json
+++ b/data/licenses/BSD-2-Clause-NetBSD.json
@@ -29,5 +29,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-Patent.json
+++ b/data/licenses/BSD-2-Clause-Patent.json
@@ -38,5 +38,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/BSD-2-Clause-Views.json
+++ b/data/licenses/BSD-2-Clause-Views.json
@@ -47,5 +47,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-first-lines.json
+++ b/data/licenses/BSD-2-Clause-first-lines.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause-pkgconf-disclaimer.json
+++ b/data/licenses/BSD-2-Clause-pkgconf-disclaimer.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-2-Clause.json
+++ b/data/licenses/BSD-2-Clause.json
@@ -36,5 +36,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/BSD-3-Clause-Attribution.json
+++ b/data/licenses/BSD-3-Clause-Attribution.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-Clear.json
+++ b/data/licenses/BSD-3-Clause-Clear.json
@@ -39,5 +39,11 @@
     "liability",
     "patent-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/BSD-3-Clause-HP.json
+++ b/data/licenses/BSD-3-Clause-HP.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-LBNL.json
+++ b/data/licenses/BSD-3-Clause-LBNL.json
@@ -27,5 +27,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-Modification.json
+++ b/data/licenses/BSD-3-Clause-Modification.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-No-Military-License.json
+++ b/data/licenses/BSD-3-Clause-No-Military-License.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-No-Nuclear-License-2014.json
+++ b/data/licenses/BSD-3-Clause-No-Nuclear-License-2014.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-No-Nuclear-License.json
+++ b/data/licenses/BSD-3-Clause-No-Nuclear-License.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-No-Nuclear-Warranty.json
+++ b/data/licenses/BSD-3-Clause-No-Nuclear-Warranty.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-Open-MPI.json
+++ b/data/licenses/BSD-3-Clause-Open-MPI.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-Sun.json
+++ b/data/licenses/BSD-3-Clause-Sun.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-acpica.json
+++ b/data/licenses/BSD-3-Clause-acpica.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause-flex.json
+++ b/data/licenses/BSD-3-Clause-flex.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-3-Clause.json
+++ b/data/licenses/BSD-3-Clause.json
@@ -48,5 +48,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/BSD-4-Clause-Shortened.json
+++ b/data/licenses/BSD-4-Clause-Shortened.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-4-Clause-UC.json
+++ b/data/licenses/BSD-4-Clause-UC.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-4-Clause.json
+++ b/data/licenses/BSD-4-Clause.json
@@ -38,5 +38,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/BSD-4.3RENO.json
+++ b/data/licenses/BSD-4.3RENO.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-4.3TAHOE.json
+++ b/data/licenses/BSD-4.3TAHOE.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Advertising-Acknowledgement.json
+++ b/data/licenses/BSD-Advertising-Acknowledgement.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Attribution-HPND-disclaimer.json
+++ b/data/licenses/BSD-Attribution-HPND-disclaimer.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Inferno-Nettverk.json
+++ b/data/licenses/BSD-Inferno-Nettverk.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Protection.json
+++ b/data/licenses/BSD-Protection.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Source-Code.json
+++ b/data/licenses/BSD-Source-Code.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Source-beginning-file.json
+++ b/data/licenses/BSD-Source-beginning-file.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Systemics-W3Works.json
+++ b/data/licenses/BSD-Systemics-W3Works.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSD-Systemics.json
+++ b/data/licenses/BSD-Systemics.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/BSL-1.0.json
+++ b/data/licenses/BSL-1.0.json
@@ -48,5 +48,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/BUSL-1.1.json
+++ b/data/licenses/BUSL-1.1.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Baekmuk.json
+++ b/data/licenses/Baekmuk.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Bahyph.json
+++ b/data/licenses/Bahyph.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Barr.json
+++ b/data/licenses/Barr.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Beerware.json
+++ b/data/licenses/Beerware.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/BitTorrent-1.0.json
+++ b/data/licenses/BitTorrent-1.0.json
@@ -28,5 +28,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/BitTorrent-1.1.json
+++ b/data/licenses/BitTorrent-1.1.json
@@ -31,5 +31,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Bitstream-Charter.json
+++ b/data/licenses/Bitstream-Charter.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Bitstream-Vera.json
+++ b/data/licenses/Bitstream-Vera.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/BlueOak-1.0.0.json
+++ b/data/licenses/BlueOak-1.0.0.json
@@ -38,5 +38,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/Boehm-GC-without-fee.json
+++ b/data/licenses/Boehm-GC-without-fee.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Boehm-GC.json
+++ b/data/licenses/Boehm-GC.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Borceux.json
+++ b/data/licenses/Borceux.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Brian-Gladman-2-Clause.json
+++ b/data/licenses/Brian-Gladman-2-Clause.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Brian-Gladman-3-Clause.json
+++ b/data/licenses/Brian-Gladman-3-Clause.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/C-UDA-1.0.json
+++ b/data/licenses/C-UDA-1.0.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CAL-1.0-Combined-Work-Exception.json
+++ b/data/licenses/CAL-1.0-Combined-Work-Exception.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CAL-1.0.json
+++ b/data/licenses/CAL-1.0.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CATOSL-1.1.json
+++ b/data/licenses/CATOSL-1.1.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CC-BY-1.0.json
+++ b/data/licenses/CC-BY-1.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-2.0.json
+++ b/data/licenses/CC-BY-2.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-2.5-AU.json
+++ b/data/licenses/CC-BY-2.5-AU.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-2.5.json
+++ b/data/licenses/CC-BY-2.5.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-AT.json
+++ b/data/licenses/CC-BY-3.0-AT.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-AU.json
+++ b/data/licenses/CC-BY-3.0-AU.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-DE.json
+++ b/data/licenses/CC-BY-3.0-DE.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-IGO.json
+++ b/data/licenses/CC-BY-3.0-IGO.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-NL.json
+++ b/data/licenses/CC-BY-3.0-NL.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0-US.json
+++ b/data/licenses/CC-BY-3.0-US.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-3.0.json
+++ b/data/licenses/CC-BY-3.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-4.0.json
+++ b/data/licenses/CC-BY-4.0.json
@@ -39,5 +39,13 @@
     "trademark-use",
     "patent-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "domain:data"
   ]
 }

--- a/data/licenses/CC-BY-NC-1.0.json
+++ b/data/licenses/CC-BY-NC-1.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-2.0.json
+++ b/data/licenses/CC-BY-NC-2.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-2.5.json
+++ b/data/licenses/CC-BY-NC-2.5.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-3.0-DE.json
+++ b/data/licenses/CC-BY-NC-3.0-DE.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-3.0.json
+++ b/data/licenses/CC-BY-NC-3.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-4.0.json
+++ b/data/licenses/CC-BY-NC-4.0.json
@@ -26,5 +26,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "domain:data"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-1.0.json
+++ b/data/licenses/CC-BY-NC-ND-1.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-2.0.json
+++ b/data/licenses/CC-BY-NC-ND-2.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-2.5.json
+++ b/data/licenses/CC-BY-NC-ND-2.5.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-3.0-DE.json
+++ b/data/licenses/CC-BY-NC-ND-3.0-DE.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-3.0-IGO.json
+++ b/data/licenses/CC-BY-NC-ND-3.0-IGO.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-3.0.json
+++ b/data/licenses/CC-BY-NC-ND-3.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-NC-ND-4.0.json
+++ b/data/licenses/CC-BY-NC-ND-4.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "domain:data"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-1.0.json
+++ b/data/licenses/CC-BY-NC-SA-1.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-2.0-DE.json
+++ b/data/licenses/CC-BY-NC-SA-2.0-DE.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-2.0-FR.json
+++ b/data/licenses/CC-BY-NC-SA-2.0-FR.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-2.0-UK.json
+++ b/data/licenses/CC-BY-NC-SA-2.0-UK.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-2.0.json
+++ b/data/licenses/CC-BY-NC-SA-2.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-2.5.json
+++ b/data/licenses/CC-BY-NC-SA-2.5.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-3.0-DE.json
+++ b/data/licenses/CC-BY-NC-SA-3.0-DE.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-3.0-IGO.json
+++ b/data/licenses/CC-BY-NC-SA-3.0-IGO.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-3.0.json
+++ b/data/licenses/CC-BY-NC-SA-3.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-NC-SA-4.0.json
+++ b/data/licenses/CC-BY-NC-SA-4.0.json
@@ -25,5 +25,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike",
+    "domain:data"
+  ]
 }

--- a/data/licenses/CC-BY-ND-1.0.json
+++ b/data/licenses/CC-BY-ND-1.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-ND-2.0.json
+++ b/data/licenses/CC-BY-ND-2.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-ND-2.5.json
+++ b/data/licenses/CC-BY-ND-2.5.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-ND-3.0-DE.json
+++ b/data/licenses/CC-BY-ND-3.0-DE.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-ND-3.0.json
+++ b/data/licenses/CC-BY-ND-3.0.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/CC-BY-ND-4.0.json
+++ b/data/licenses/CC-BY-ND-4.0.json
@@ -26,5 +26,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "domain:data"
+  ]
 }

--- a/data/licenses/CC-BY-SA-1.0.json
+++ b/data/licenses/CC-BY-SA-1.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-2.0-UK.json
+++ b/data/licenses/CC-BY-SA-2.0-UK.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-2.0.json
+++ b/data/licenses/CC-BY-SA-2.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-2.1-JP.json
+++ b/data/licenses/CC-BY-SA-2.1-JP.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-2.5.json
+++ b/data/licenses/CC-BY-SA-2.5.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-3.0-AT.json
+++ b/data/licenses/CC-BY-SA-3.0-AT.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-3.0-DE.json
+++ b/data/licenses/CC-BY-SA-3.0-DE.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-3.0-IGO.json
+++ b/data/licenses/CC-BY-SA-3.0-IGO.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-3.0.json
+++ b/data/licenses/CC-BY-SA-3.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC-BY-SA-4.0.json
+++ b/data/licenses/CC-BY-SA-4.0.json
@@ -40,5 +40,14 @@
     "trademark-use",
     "patent-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:attribution-required",
+    "notes:share-alike",
+    "domain:data"
   ]
 }

--- a/data/licenses/CC-PDDC.json
+++ b/data/licenses/CC-PDDC.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content"
+  ]
 }

--- a/data/licenses/CC-PDM-1.0.json
+++ b/data/licenses/CC-PDM-1.0.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content"
+  ]
 }

--- a/data/licenses/CC-SA-1.0.json
+++ b/data/licenses/CC-SA-1.0.json
@@ -25,5 +25,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:creative-commons",
+    "family:CC",
+    "domain:content",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/CC0-1.0.json
+++ b/data/licenses/CC0-1.0.json
@@ -36,5 +36,12 @@
     "trademark-use",
     "patent-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:public-domain",
+    "copyleft:none",
+    "domain:content",
+    "domain:data"
   ]
 }

--- a/data/licenses/CDDL-1.0.json
+++ b/data/licenses/CDDL-1.0.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/CDDL-1.1.json
+++ b/data/licenses/CDDL-1.1.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/CDL-1.0.json
+++ b/data/licenses/CDL-1.0.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CDLA-Permissive-1.0.json
+++ b/data/licenses/CDLA-Permissive-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CDLA-Permissive-2.0.json
+++ b/data/licenses/CDLA-Permissive-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CDLA-Sharing-1.0.json
+++ b/data/licenses/CDLA-Sharing-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CECILL-1.0.json
+++ b/data/licenses/CECILL-1.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CECILL-1.1.json
+++ b/data/licenses/CECILL-1.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CECILL-2.0.json
+++ b/data/licenses/CECILL-2.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CECILL-2.1.json
+++ b/data/licenses/CECILL-2.1.json
@@ -41,5 +41,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/CECILL-B.json
+++ b/data/licenses/CECILL-B.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CECILL-C.json
+++ b/data/licenses/CECILL-C.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CERN-OHL-1.1.json
+++ b/data/licenses/CERN-OHL-1.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CERN-OHL-1.2.json
+++ b/data/licenses/CERN-OHL-1.2.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CERN-OHL-P-2.0.json
+++ b/data/licenses/CERN-OHL-P-2.0.json
@@ -37,5 +37,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/CERN-OHL-S-2.0.json
+++ b/data/licenses/CERN-OHL-S-2.0.json
@@ -39,5 +39,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/CERN-OHL-W-2.0.json
+++ b/data/licenses/CERN-OHL-W-2.0.json
@@ -39,5 +39,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/CFITSIO.json
+++ b/data/licenses/CFITSIO.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CMU-Mach-nodoc.json
+++ b/data/licenses/CMU-Mach-nodoc.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CMU-Mach.json
+++ b/data/licenses/CMU-Mach.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CNRI-Jython.json
+++ b/data/licenses/CNRI-Jython.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CNRI-Python-GPL-Compatible.json
+++ b/data/licenses/CNRI-Python-GPL-Compatible.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CNRI-Python.json
+++ b/data/licenses/CNRI-Python.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/COIL-1.0.json
+++ b/data/licenses/COIL-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CPAL-1.0.json
+++ b/data/licenses/CPAL-1.0.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CPL-1.0.json
+++ b/data/licenses/CPL-1.0.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CPOL-1.02.json
+++ b/data/licenses/CPOL-1.02.json
@@ -26,5 +26,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CUA-OPL-1.0.json
+++ b/data/licenses/CUA-OPL-1.0.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Caldera-no-preamble.json
+++ b/data/licenses/Caldera-no-preamble.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Caldera.json
+++ b/data/licenses/Caldera.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Catharon.json
+++ b/data/licenses/Catharon.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ClArtistic.json
+++ b/data/licenses/ClArtistic.json
@@ -36,5 +36,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Clips.json
+++ b/data/licenses/Clips.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Community-Spec-1.0.json
+++ b/data/licenses/Community-Spec-1.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Condor-1.1.json
+++ b/data/licenses/Condor-1.1.json
@@ -38,5 +38,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Cornell-Lossless-JPEG.json
+++ b/data/licenses/Cornell-Lossless-JPEG.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Cronyx.json
+++ b/data/licenses/Cronyx.json
@@ -55,5 +55,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Crossword.json
+++ b/data/licenses/Crossword.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CryptoSwift.json
+++ b/data/licenses/CryptoSwift.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/CrystalStacker.json
+++ b/data/licenses/CrystalStacker.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Cube.json
+++ b/data/licenses/Cube.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/D-FSL-1.0.json
+++ b/data/licenses/D-FSL-1.0.json
@@ -97,5 +97,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DEC-3-Clause.json
+++ b/data/licenses/DEC-3-Clause.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DL-DE-BY-2.0.json
+++ b/data/licenses/DL-DE-BY-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DL-DE-ZERO-2.0.json
+++ b/data/licenses/DL-DE-ZERO-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DOC.json
+++ b/data/licenses/DOC.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DRL-1.0.json
+++ b/data/licenses/DRL-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DRL-1.1.json
+++ b/data/licenses/DRL-1.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DSDP.json
+++ b/data/licenses/DSDP.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DocBook-DTD.json
+++ b/data/licenses/DocBook-DTD.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DocBook-Schema.json
+++ b/data/licenses/DocBook-Schema.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DocBook-Stylesheet.json
+++ b/data/licenses/DocBook-Stylesheet.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/DocBook-XML.json
+++ b/data/licenses/DocBook-XML.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Dotseqn.json
+++ b/data/licenses/Dotseqn.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ECL-1.0.json
+++ b/data/licenses/ECL-1.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ECL-2.0.json
+++ b/data/licenses/ECL-2.0.json
@@ -44,5 +44,11 @@
     "trademark-use",
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/EFL-1.0.json
+++ b/data/licenses/EFL-1.0.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/EFL-2.0.json
+++ b/data/licenses/EFL-2.0.json
@@ -36,5 +36,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/EPICS.json
+++ b/data/licenses/EPICS.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/EPL-1.0.json
+++ b/data/licenses/EPL-1.0.json
@@ -51,5 +51,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
   ]
 }

--- a/data/licenses/EPL-2.0.json
+++ b/data/licenses/EPL-2.0.json
@@ -71,5 +71,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
   ]
 }

--- a/data/licenses/EUDatagrid.json
+++ b/data/licenses/EUDatagrid.json
@@ -36,5 +36,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/EUPL-1.0.json
+++ b/data/licenses/EUPL-1.0.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/EUPL-1.1.json
+++ b/data/licenses/EUPL-1.1.json
@@ -64,5 +64,11 @@
     "liability",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/EUPL-1.2.json
+++ b/data/licenses/EUPL-1.2.json
@@ -94,5 +94,11 @@
     "liability",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/Elastic-2.0.json
+++ b/data/licenses/Elastic-2.0.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Entessa.json
+++ b/data/licenses/Entessa.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ErlPL-1.1.json
+++ b/data/licenses/ErlPL-1.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Eurosym.json
+++ b/data/licenses/Eurosym.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FBM.json
+++ b/data/licenses/FBM.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FDK-AAC.json
+++ b/data/licenses/FDK-AAC.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFAP-no-warranty-disclaimer.json
+++ b/data/licenses/FSFAP-no-warranty-disclaimer.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFAP.json
+++ b/data/licenses/FSFAP.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFUL.json
+++ b/data/licenses/FSFUL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFULLR.json
+++ b/data/licenses/FSFULLR.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFULLRSD.json
+++ b/data/licenses/FSFULLRSD.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSFULLRWD.json
+++ b/data/licenses/FSFULLRWD.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSL-1.1-ALv2.json
+++ b/data/licenses/FSL-1.1-ALv2.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FSL-1.1-MIT.json
+++ b/data/licenses/FSL-1.1-MIT.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FTL.json
+++ b/data/licenses/FTL.json
@@ -48,5 +48,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Fair.json
+++ b/data/licenses/Fair.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Ferguson-Twofish.json
+++ b/data/licenses/Ferguson-Twofish.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Frameworx-1.0.json
+++ b/data/licenses/Frameworx-1.0.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FreeBSD-DOC.json
+++ b/data/licenses/FreeBSD-DOC.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/FreeImage.json
+++ b/data/licenses/FreeImage.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Furuseth.json
+++ b/data/licenses/Furuseth.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/GCR-docs.json
+++ b/data/licenses/GCR-docs.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/GD.json
+++ b/data/licenses/GD.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/GFDL-1.1-invariants-only.json
+++ b/data/licenses/GFDL-1.1-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1-invariants-or-later.json
+++ b/data/licenses/GFDL-1.1-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1-no-invariants-only.json
+++ b/data/licenses/GFDL-1.1-no-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1-no-invariants-or-later.json
+++ b/data/licenses/GFDL-1.1-no-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1-only.json
+++ b/data/licenses/GFDL-1.1-only.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1-or-later.json
+++ b/data/licenses/GFDL-1.1-or-later.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.1.json
+++ b/data/licenses/GFDL-1.1.json
@@ -30,5 +30,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-invariants-only.json
+++ b/data/licenses/GFDL-1.2-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-invariants-or-later.json
+++ b/data/licenses/GFDL-1.2-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-no-invariants-only.json
+++ b/data/licenses/GFDL-1.2-no-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-no-invariants-or-later.json
+++ b/data/licenses/GFDL-1.2-no-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-only.json
+++ b/data/licenses/GFDL-1.2-only.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2-or-later.json
+++ b/data/licenses/GFDL-1.2-or-later.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.2.json
+++ b/data/licenses/GFDL-1.2.json
@@ -30,5 +30,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-invariants-only.json
+++ b/data/licenses/GFDL-1.3-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-invariants-or-later.json
+++ b/data/licenses/GFDL-1.3-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-no-invariants-only.json
+++ b/data/licenses/GFDL-1.3-no-invariants-only.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-no-invariants-or-later.json
+++ b/data/licenses/GFDL-1.3-no-invariants-or-later.json
@@ -30,5 +30,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-only.json
+++ b/data/licenses/GFDL-1.3-only.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3-or-later.json
+++ b/data/licenses/GFDL-1.3-or-later.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
+  ]
 }

--- a/data/licenses/GFDL-1.3.json
+++ b/data/licenses/GFDL-1.3.json
@@ -43,5 +43,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:documentation",
+    "domain:content"
   ]
 }

--- a/data/licenses/GL2PS.json
+++ b/data/licenses/GL2PS.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/GLWTPL.json
+++ b/data/licenses/GLWTPL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/GPL-1.0+.json
+++ b/data/licenses/GPL-1.0+.json
@@ -29,5 +29,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-1.0-only.json
+++ b/data/licenses/GPL-1.0-only.json
@@ -30,5 +30,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-1.0-or-later.json
+++ b/data/licenses/GPL-1.0-or-later.json
@@ -30,5 +30,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-1.0.json
+++ b/data/licenses/GPL-1.0.json
@@ -29,5 +29,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0+.json
+++ b/data/licenses/GPL-2.0+.json
@@ -40,5 +40,14 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-only.json
+++ b/data/licenses/GPL-2.0-only.json
@@ -51,5 +51,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-or-later.json
+++ b/data/licenses/GPL-2.0-or-later.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-with-GCC-exception.json
+++ b/data/licenses/GPL-2.0-with-GCC-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-with-autoconf-exception.json
+++ b/data/licenses/GPL-2.0-with-autoconf-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-with-bison-exception.json
+++ b/data/licenses/GPL-2.0-with-bison-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-with-classpath-exception.json
+++ b/data/licenses/GPL-2.0-with-classpath-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0-with-font-exception.json
+++ b/data/licenses/GPL-2.0-with-font-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-2.0.json
+++ b/data/licenses/GPL-2.0.json
@@ -53,5 +53,14 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
   ]
 }

--- a/data/licenses/GPL-3.0+.json
+++ b/data/licenses/GPL-3.0+.json
@@ -40,5 +40,14 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-3.0-only.json
+++ b/data/licenses/GPL-3.0-only.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-3.0-or-later.json
+++ b/data/licenses/GPL-3.0-or-later.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-3.0-with-GCC-exception.json
+++ b/data/licenses/GPL-3.0-with-GCC-exception.json
@@ -28,5 +28,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-3.0-with-autoconf-exception.json
+++ b/data/licenses/GPL-3.0-with-autoconf-exception.json
@@ -28,5 +28,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
+  ]
 }

--- a/data/licenses/GPL-3.0.json
+++ b/data/licenses/GPL-3.0.json
@@ -54,5 +54,14 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:GPL",
+    "domain:software",
+    "copyleft:strong"
   ]
 }

--- a/data/licenses/Game-Programming-Gems.json
+++ b/data/licenses/Game-Programming-Gems.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Giftware.json
+++ b/data/licenses/Giftware.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Glide.json
+++ b/data/licenses/Glide.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Glulxe.json
+++ b/data/licenses/Glulxe.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Graphics-Gems.json
+++ b/data/licenses/Graphics-Gems.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Gutmann.json
+++ b/data/licenses/Gutmann.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HDF5.json
+++ b/data/licenses/HDF5.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HIDAPI.json
+++ b/data/licenses/HIDAPI.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HP-1986.json
+++ b/data/licenses/HP-1986.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HP-1989.json
+++ b/data/licenses/HP-1989.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-DEC.json
+++ b/data/licenses/HPND-DEC.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Fenneberg-Livingston.json
+++ b/data/licenses/HPND-Fenneberg-Livingston.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-INRIA-IMAG.json
+++ b/data/licenses/HPND-INRIA-IMAG.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Intel.json
+++ b/data/licenses/HPND-Intel.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Kevlin-Henney.json
+++ b/data/licenses/HPND-Kevlin-Henney.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-MIT-disclaimer.json
+++ b/data/licenses/HPND-MIT-disclaimer.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Markus-Kuhn.json
+++ b/data/licenses/HPND-Markus-Kuhn.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Netrek.json
+++ b/data/licenses/HPND-Netrek.json
@@ -13,5 +13,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-Pbmplus.json
+++ b/data/licenses/HPND-Pbmplus.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-UC-export-US.json
+++ b/data/licenses/HPND-UC-export-US.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-UC.json
+++ b/data/licenses/HPND-UC.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-doc-sell.json
+++ b/data/licenses/HPND-doc-sell.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-doc.json
+++ b/data/licenses/HPND-doc.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-export-US-acknowledgement.json
+++ b/data/licenses/HPND-export-US-acknowledgement.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-export-US-modify.json
+++ b/data/licenses/HPND-export-US-modify.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-export-US.json
+++ b/data/licenses/HPND-export-US.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-export2-US.json
+++ b/data/licenses/HPND-export2-US.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-merchantability-variant.json
+++ b/data/licenses/HPND-merchantability-variant.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-sell-MIT-disclaimer-xserver.json
+++ b/data/licenses/HPND-sell-MIT-disclaimer-xserver.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-sell-regexpr.json
+++ b/data/licenses/HPND-sell-regexpr.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-sell-variant-MIT-disclaimer-rev.json
+++ b/data/licenses/HPND-sell-variant-MIT-disclaimer-rev.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-sell-variant-MIT-disclaimer.json
+++ b/data/licenses/HPND-sell-variant-MIT-disclaimer.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND-sell-variant.json
+++ b/data/licenses/HPND-sell-variant.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HPND.json
+++ b/data/licenses/HPND.json
@@ -38,5 +38,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HTMLTIDY.json
+++ b/data/licenses/HTMLTIDY.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/HaskellReport.json
+++ b/data/licenses/HaskellReport.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Hippocratic-2.1.json
+++ b/data/licenses/Hippocratic-2.1.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IBM-pibs.json
+++ b/data/licenses/IBM-pibs.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ICU.json
+++ b/data/licenses/ICU.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IEC-Code-Components-EULA.json
+++ b/data/licenses/IEC-Code-Components-EULA.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IJG-short.json
+++ b/data/licenses/IJG-short.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IJG.json
+++ b/data/licenses/IJG.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IPA.json
+++ b/data/licenses/IPA.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/IPL-1.0.json
+++ b/data/licenses/IPL-1.0.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ISC-Veillard.json
+++ b/data/licenses/ISC-Veillard.json
@@ -47,5 +47,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/ISC.json
+++ b/data/licenses/ISC.json
@@ -58,5 +58,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/ImageMagick.json
+++ b/data/licenses/ImageMagick.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Imlib2.json
+++ b/data/licenses/Imlib2.json
@@ -36,5 +36,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Info-ZIP.json
+++ b/data/licenses/Info-ZIP.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Inner-Net-2.0.json
+++ b/data/licenses/Inner-Net-2.0.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/InnoSetup.json
+++ b/data/licenses/InnoSetup.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Intel-ACPI.json
+++ b/data/licenses/Intel-ACPI.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Intel.json
+++ b/data/licenses/Intel.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Interbase-1.0.json
+++ b/data/licenses/Interbase-1.0.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/JPL-image.json
+++ b/data/licenses/JPL-image.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/JPNIC.json
+++ b/data/licenses/JPNIC.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/JSON.json
+++ b/data/licenses/JSON.json
@@ -26,5 +26,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Jam.json
+++ b/data/licenses/Jam.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/JasPer-2.0.json
+++ b/data/licenses/JasPer-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Kastrup.json
+++ b/data/licenses/Kastrup.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Kazlib.json
+++ b/data/licenses/Kazlib.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Knuth-CTAN.json
+++ b/data/licenses/Knuth-CTAN.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LAL-1.2.json
+++ b/data/licenses/LAL-1.2.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LAL-1.3.json
+++ b/data/licenses/LAL-1.3.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LGPL-2.0+.json
+++ b/data/licenses/LGPL-2.0+.json
@@ -29,5 +29,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.0-only.json
+++ b/data/licenses/LGPL-2.0-only.json
@@ -30,5 +30,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.0-or-later.json
+++ b/data/licenses/LGPL-2.0-or-later.json
@@ -30,5 +30,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.0.json
+++ b/data/licenses/LGPL-2.0.json
@@ -29,5 +29,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.1+.json
+++ b/data/licenses/LGPL-2.1+.json
@@ -40,5 +40,14 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.1-only.json
+++ b/data/licenses/LGPL-2.1-only.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.1-or-later.json
+++ b/data/licenses/LGPL-2.1-or-later.json
@@ -41,5 +41,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-2.1.json
+++ b/data/licenses/LGPL-2.1.json
@@ -53,5 +53,14 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
   ]
 }

--- a/data/licenses/LGPL-3.0+.json
+++ b/data/licenses/LGPL-3.0+.json
@@ -49,5 +49,14 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-3.0-only.json
+++ b/data/licenses/LGPL-3.0-only.json
@@ -48,5 +48,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-3.0-or-later.json
+++ b/data/licenses/LGPL-3.0-or-later.json
@@ -48,5 +48,13 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/LGPL-3.0.json
+++ b/data/licenses/LGPL-3.0.json
@@ -63,5 +63,14 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "family:LGPL",
+    "domain:software",
+    "copyleft:weak"
   ]
 }

--- a/data/licenses/LGPLLR.json
+++ b/data/licenses/LGPLLR.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LOOP.json
+++ b/data/licenses/LOOP.json
@@ -75,5 +75,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPD-document.json
+++ b/data/licenses/LPD-document.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPL-1.0.json
+++ b/data/licenses/LPL-1.0.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPL-1.02.json
+++ b/data/licenses/LPL-1.02.json
@@ -36,5 +36,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPPL-1.0.json
+++ b/data/licenses/LPPL-1.0.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPPL-1.1.json
+++ b/data/licenses/LPPL-1.1.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPPL-1.2.json
+++ b/data/licenses/LPPL-1.2.json
@@ -31,5 +31,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPPL-1.3a.json
+++ b/data/licenses/LPPL-1.3a.json
@@ -31,5 +31,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LPPL-1.3c.json
+++ b/data/licenses/LPPL-1.3c.json
@@ -52,5 +52,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/LZMA-SDK-9.11-to-9.20.json
+++ b/data/licenses/LZMA-SDK-9.11-to-9.20.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LZMA-SDK-9.22.json
+++ b/data/licenses/LZMA-SDK-9.22.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Latex2e-translated-notice.json
+++ b/data/licenses/Latex2e-translated-notice.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Latex2e.json
+++ b/data/licenses/Latex2e.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Leptonica.json
+++ b/data/licenses/Leptonica.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LiLiQ-P-1.1.json
+++ b/data/licenses/LiLiQ-P-1.1.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LiLiQ-R-1.1.json
+++ b/data/licenses/LiLiQ-R-1.1.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/LiLiQ-Rplus-1.1.json
+++ b/data/licenses/LiLiQ-Rplus-1.1.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Libpng.json
+++ b/data/licenses/Libpng.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Linux-OpenIB.json
+++ b/data/licenses/Linux-OpenIB.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Linux-man-pages-1-para.json
+++ b/data/licenses/Linux-man-pages-1-para.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Linux-man-pages-copyleft-2-para.json
+++ b/data/licenses/Linux-man-pages-copyleft-2-para.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Linux-man-pages-copyleft-var.json
+++ b/data/licenses/Linux-man-pages-copyleft-var.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Linux-man-pages-copyleft.json
+++ b/data/licenses/Linux-man-pages-copyleft.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Lucida-Bitmap-Fonts.json
+++ b/data/licenses/Lucida-Bitmap-Fonts.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MIPS.json
+++ b/data/licenses/MIPS.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MIT-0.json
+++ b/data/licenses/MIT-0.json
@@ -55,5 +55,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/MIT-CMU.json
+++ b/data/licenses/MIT-CMU.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-Click.json
+++ b/data/licenses/MIT-Click.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-Festival.json
+++ b/data/licenses/MIT-Festival.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-Khronos-old.json
+++ b/data/licenses/MIT-Khronos-old.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-Modern-Variant.json
+++ b/data/licenses/MIT-Modern-Variant.json
@@ -47,5 +47,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-Wu.json
+++ b/data/licenses/MIT-Wu.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-advertising.json
+++ b/data/licenses/MIT-advertising.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-enna.json
+++ b/data/licenses/MIT-enna.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-feh.json
+++ b/data/licenses/MIT-feh.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-open-group.json
+++ b/data/licenses/MIT-open-group.json
@@ -45,5 +45,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT-testregex.json
+++ b/data/licenses/MIT-testregex.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MIT.json
+++ b/data/licenses/MIT.json
@@ -46,5 +46,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/MITNFA.json
+++ b/data/licenses/MITNFA.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/licenses/MMIXware.json
+++ b/data/licenses/MMIXware.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MPEG-SSG.json
+++ b/data/licenses/MPEG-SSG.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MPL-1.0.json
+++ b/data/licenses/MPL-1.0.json
@@ -40,5 +40,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/MPL-1.1.json
+++ b/data/licenses/MPL-1.1.json
@@ -41,5 +41,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/MPL-2.0-no-copyleft-exception.json
+++ b/data/licenses/MPL-2.0-no-copyleft-exception.json
@@ -40,5 +40,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
+  ]
 }

--- a/data/licenses/MPL-2.0.json
+++ b/data/licenses/MPL-2.0.json
@@ -55,5 +55,12 @@
     "liability",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:weak"
   ]
 }

--- a/data/licenses/MS-LPL.json
+++ b/data/licenses/MS-LPL.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MS-PL.json
+++ b/data/licenses/MS-PL.json
@@ -47,5 +47,11 @@
   "limitations": [
     "warranty",
     "trademark-use"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/MS-RL.json
+++ b/data/licenses/MS-RL.json
@@ -49,5 +49,11 @@
   "limitations": [
     "warranty",
     "trademark-use"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/MTLL.json
+++ b/data/licenses/MTLL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Mackerras-3-Clause-acknowledgment.json
+++ b/data/licenses/Mackerras-3-Clause-acknowledgment.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Mackerras-3-Clause.json
+++ b/data/licenses/Mackerras-3-Clause.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MakeIndex.json
+++ b/data/licenses/MakeIndex.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Martin-Birgmeier.json
+++ b/data/licenses/Martin-Birgmeier.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/McPhee-slideshow.json
+++ b/data/licenses/McPhee-slideshow.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Minpack.json
+++ b/data/licenses/Minpack.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MirOS.json
+++ b/data/licenses/MirOS.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Motosoto.json
+++ b/data/licenses/Motosoto.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MulanPSL-1.0.json
+++ b/data/licenses/MulanPSL-1.0.json
@@ -40,5 +40,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/MulanPSL-2.0.json
+++ b/data/licenses/MulanPSL-2.0.json
@@ -42,5 +42,10 @@
     "liability",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/Multics.json
+++ b/data/licenses/Multics.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Mup.json
+++ b/data/licenses/Mup.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NAIST-2003.json
+++ b/data/licenses/NAIST-2003.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NASA-1.3.json
+++ b/data/licenses/NASA-1.3.json
@@ -36,5 +36,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NBPL-1.0.json
+++ b/data/licenses/NBPL-1.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NCBI-PD.json
+++ b/data/licenses/NCBI-PD.json
@@ -65,5 +65,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NCGL-UK-2.0.json
+++ b/data/licenses/NCGL-UK-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NCL.json
+++ b/data/licenses/NCL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NCSA.json
+++ b/data/licenses/NCSA.json
@@ -46,5 +46,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/NGPL.json
+++ b/data/licenses/NGPL.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NICTA-1.0.json
+++ b/data/licenses/NICTA-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NIST-PD-fallback.json
+++ b/data/licenses/NIST-PD-fallback.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NIST-PD.json
+++ b/data/licenses/NIST-PD.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NIST-Software.json
+++ b/data/licenses/NIST-Software.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NLOD-1.0.json
+++ b/data/licenses/NLOD-1.0.json
@@ -27,5 +27,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/NLOD-2.0.json
+++ b/data/licenses/NLOD-2.0.json
@@ -27,5 +27,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/NLPL.json
+++ b/data/licenses/NLPL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NOSL.json
+++ b/data/licenses/NOSL.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NPL-1.0.json
+++ b/data/licenses/NPL-1.0.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NPL-1.1.json
+++ b/data/licenses/NPL-1.1.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NPOSL-3.0.json
+++ b/data/licenses/NPOSL-3.0.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NRL.json
+++ b/data/licenses/NRL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NTIA-PD.json
+++ b/data/licenses/NTIA-PD.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NTP-0.json
+++ b/data/licenses/NTP-0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NTP.json
+++ b/data/licenses/NTP.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Naumen.json
+++ b/data/licenses/Naumen.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Net-SNMP.json
+++ b/data/licenses/Net-SNMP.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/NetCDF.json
+++ b/data/licenses/NetCDF.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Newsletr.json
+++ b/data/licenses/Newsletr.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Nokia.json
+++ b/data/licenses/Nokia.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Noweb.json
+++ b/data/licenses/Noweb.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Nunit.json
+++ b/data/licenses/Nunit.json
@@ -27,5 +27,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/O-UDA-1.0.json
+++ b/data/licenses/O-UDA-1.0.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OAR.json
+++ b/data/licenses/OAR.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OCCT-PL.json
+++ b/data/licenses/OCCT-PL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OCLC-2.0.json
+++ b/data/licenses/OCLC-2.0.json
@@ -40,5 +40,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ODC-By-1.0.json
+++ b/data/licenses/ODC-By-1.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-data-commons",
+    "family:ODC",
+    "domain:data",
+    "notes:attribution-required",
+    "notes:share-alike"
+  ]
 }

--- a/data/licenses/ODbL-1.0.json
+++ b/data/licenses/ODbL-1.0.json
@@ -50,5 +50,13 @@
     "patent-use",
     "trademark-use",
     "warranty"
+  ],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-data-commons",
+    "family:ODC",
+    "domain:data",
+    "notes:attribution-required",
+    "notes:share-alike"
   ]
 }

--- a/data/licenses/OFFIS.json
+++ b/data/licenses/OFFIS.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.0-RFN.json
+++ b/data/licenses/OFL-1.0-RFN.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.0-no-RFN.json
+++ b/data/licenses/OFL-1.0-no-RFN.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.0.json
+++ b/data/licenses/OFL-1.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.1-RFN.json
+++ b/data/licenses/OFL-1.1-RFN.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.1-no-RFN.json
+++ b/data/licenses/OFL-1.1-no-RFN.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OFL-1.1.json
+++ b/data/licenses/OFL-1.1.json
@@ -49,5 +49,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/OGC-1.0.json
+++ b/data/licenses/OGC-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OGDL-Taiwan-1.0.json
+++ b/data/licenses/OGDL-Taiwan-1.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OGL-Canada-2.0.json
+++ b/data/licenses/OGL-Canada-2.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/OGL-UK-1.0.json
+++ b/data/licenses/OGL-UK-1.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/OGL-UK-2.0.json
+++ b/data/licenses/OGL-UK-2.0.json
@@ -25,5 +25,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/OGL-UK-3.0.json
+++ b/data/licenses/OGL-UK-3.0.json
@@ -27,5 +27,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/OGTSL.json
+++ b/data/licenses/OGTSL.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-1.1.json
+++ b/data/licenses/OLDAP-1.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-1.2.json
+++ b/data/licenses/OLDAP-1.2.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-1.3.json
+++ b/data/licenses/OLDAP-1.3.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-1.4.json
+++ b/data/licenses/OLDAP-1.4.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.0.1.json
+++ b/data/licenses/OLDAP-2.0.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.0.json
+++ b/data/licenses/OLDAP-2.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.1.json
+++ b/data/licenses/OLDAP-2.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.2.1.json
+++ b/data/licenses/OLDAP-2.2.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.2.2.json
+++ b/data/licenses/OLDAP-2.2.2.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.2.json
+++ b/data/licenses/OLDAP-2.2.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.3.json
+++ b/data/licenses/OLDAP-2.3.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.4.json
+++ b/data/licenses/OLDAP-2.4.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.5.json
+++ b/data/licenses/OLDAP-2.5.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.6.json
+++ b/data/licenses/OLDAP-2.6.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.7.json
+++ b/data/licenses/OLDAP-2.7.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLDAP-2.8.json
+++ b/data/licenses/OLDAP-2.8.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OLFL-1.3.json
+++ b/data/licenses/OLFL-1.3.json
@@ -37,5 +37,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OML.json
+++ b/data/licenses/OML.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OPL-1.0.json
+++ b/data/licenses/OPL-1.0.json
@@ -36,5 +36,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OPL-UK-3.0.json
+++ b/data/licenses/OPL-UK-3.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OPUBL-1.0.json
+++ b/data/licenses/OPUBL-1.0.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSET-PL-2.1.json
+++ b/data/licenses/OSET-PL-2.1.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSL-1.0.json
+++ b/data/licenses/OSL-1.0.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSL-1.1.json
+++ b/data/licenses/OSL-1.1.json
@@ -29,5 +29,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSL-2.0.json
+++ b/data/licenses/OSL-2.0.json
@@ -29,5 +29,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSL-2.1.json
+++ b/data/licenses/OSL-2.1.json
@@ -41,5 +41,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OSL-3.0.json
+++ b/data/licenses/OSL-3.0.json
@@ -55,5 +55,11 @@
     "trademark-use",
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/OpenPBS-2.3.json
+++ b/data/licenses/OpenPBS-2.3.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OpenSSL-standalone.json
+++ b/data/licenses/OpenSSL-standalone.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OpenSSL.json
+++ b/data/licenses/OpenSSL.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/OpenVision.json
+++ b/data/licenses/OpenVision.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PADL.json
+++ b/data/licenses/PADL.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PDDL-1.0.json
+++ b/data/licenses/PDDL-1.0.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-data-commons",
+    "family:ODC",
+    "domain:data"
+  ]
 }

--- a/data/licenses/PHP-3.0.json
+++ b/data/licenses/PHP-3.0.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PHP-3.01.json
+++ b/data/licenses/PHP-3.01.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PPL.json
+++ b/data/licenses/PPL.json
@@ -38,5 +38,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PSF-2.0.json
+++ b/data/licenses/PSF-2.0.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Parity-6.0.0.json
+++ b/data/licenses/Parity-6.0.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Parity-7.0.0.json
+++ b/data/licenses/Parity-7.0.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Pixar.json
+++ b/data/licenses/Pixar.json
@@ -50,5 +50,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Plexus.json
+++ b/data/licenses/Plexus.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PolyForm-Noncommercial-1.0.0.json
+++ b/data/licenses/PolyForm-Noncommercial-1.0.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PolyForm-Small-Business-1.0.0.json
+++ b/data/licenses/PolyForm-Small-Business-1.0.0.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/PostgreSQL.json
+++ b/data/licenses/PostgreSQL.json
@@ -45,5 +45,10 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/Python-2.0.1.json
+++ b/data/licenses/Python-2.0.1.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Python-2.0.json
+++ b/data/licenses/Python-2.0.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/QPL-1.0-INRIA-2004.json
+++ b/data/licenses/QPL-1.0-INRIA-2004.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/QPL-1.0.json
+++ b/data/licenses/QPL-1.0.json
@@ -46,5 +46,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Qhull.json
+++ b/data/licenses/Qhull.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RHeCos-1.1.json
+++ b/data/licenses/RHeCos-1.1.json
@@ -26,5 +26,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RPL-1.1.json
+++ b/data/licenses/RPL-1.1.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RPL-1.5.json
+++ b/data/licenses/RPL-1.5.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RPSL-1.0.json
+++ b/data/licenses/RPSL-1.0.json
@@ -39,5 +39,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RSA-MD.json
+++ b/data/licenses/RSA-MD.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/RSCPL.json
+++ b/data/licenses/RSCPL.json
@@ -35,5 +35,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Rdisc.json
+++ b/data/licenses/Rdisc.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Ruby-pty.json
+++ b/data/licenses/Ruby-pty.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Ruby.json
+++ b/data/licenses/Ruby.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SAX-PD-2.0.json
+++ b/data/licenses/SAX-PD-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SAX-PD.json
+++ b/data/licenses/SAX-PD.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SCEA.json
+++ b/data/licenses/SCEA.json
@@ -28,5 +28,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SGI-B-1.0.json
+++ b/data/licenses/SGI-B-1.0.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SGI-B-1.1.json
+++ b/data/licenses/SGI-B-1.1.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SGI-B-2.0.json
+++ b/data/licenses/SGI-B-2.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SGI-OpenGL.json
+++ b/data/licenses/SGI-OpenGL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SGP4.json
+++ b/data/licenses/SGP4.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SHL-0.5.json
+++ b/data/licenses/SHL-0.5.json
@@ -28,5 +28,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SHL-0.51.json
+++ b/data/licenses/SHL-0.51.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SISSL-1.2.json
+++ b/data/licenses/SISSL-1.2.json
@@ -28,5 +28,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SISSL.json
+++ b/data/licenses/SISSL.json
@@ -39,5 +39,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SL.json
+++ b/data/licenses/SL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SMAIL-GPL.json
+++ b/data/licenses/SMAIL-GPL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SMLNJ.json
+++ b/data/licenses/SMLNJ.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SMPPL.json
+++ b/data/licenses/SMPPL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SNIA.json
+++ b/data/licenses/SNIA.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SOFA.json
+++ b/data/licenses/SOFA.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SPL-1.0.json
+++ b/data/licenses/SPL-1.0.json
@@ -31,5 +31,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SSH-OpenSSH.json
+++ b/data/licenses/SSH-OpenSSH.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SSH-short.json
+++ b/data/licenses/SSH-short.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SSLeay-standalone.json
+++ b/data/licenses/SSLeay-standalone.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SSPL-1.0.json
+++ b/data/licenses/SSPL-1.0.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SWL.json
+++ b/data/licenses/SWL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Saxpath.json
+++ b/data/licenses/Saxpath.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SchemeReport.json
+++ b/data/licenses/SchemeReport.json
@@ -15,5 +15,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sendmail-8.23.json
+++ b/data/licenses/Sendmail-8.23.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sendmail-Open-Source-1.1.json
+++ b/data/licenses/Sendmail-Open-Source-1.1.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sendmail.json
+++ b/data/licenses/Sendmail.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SimPL-2.0.json
+++ b/data/licenses/SimPL-2.0.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sleepycat.json
+++ b/data/licenses/Sleepycat.json
@@ -26,5 +26,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Soundex.json
+++ b/data/licenses/Soundex.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Spencer-86.json
+++ b/data/licenses/Spencer-86.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Spencer-94.json
+++ b/data/licenses/Spencer-94.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Spencer-99.json
+++ b/data/licenses/Spencer-99.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/StandardML-NJ.json
+++ b/data/licenses/StandardML-NJ.json
@@ -29,5 +29,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SugarCRM-1.1.3.json
+++ b/data/licenses/SugarCRM-1.1.3.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sun-PPP-2000.json
+++ b/data/licenses/Sun-PPP-2000.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Sun-PPP.json
+++ b/data/licenses/Sun-PPP.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/SunPro.json
+++ b/data/licenses/SunPro.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Symlinks.json
+++ b/data/licenses/Symlinks.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TAPR-OHL-1.0.json
+++ b/data/licenses/TAPR-OHL-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TCL.json
+++ b/data/licenses/TCL.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TCP-wrappers.json
+++ b/data/licenses/TCP-wrappers.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TGPPL-1.0.json
+++ b/data/licenses/TGPPL-1.0.json
@@ -38,5 +38,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TMate.json
+++ b/data/licenses/TMate.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TORQUE-1.1.json
+++ b/data/licenses/TORQUE-1.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TOSL.json
+++ b/data/licenses/TOSL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TPDL.json
+++ b/data/licenses/TPDL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TPL-1.0.json
+++ b/data/licenses/TPL-1.0.json
@@ -30,5 +30,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TTWL.json
+++ b/data/licenses/TTWL.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TTYP0.json
+++ b/data/licenses/TTYP0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TU-Berlin-1.0.json
+++ b/data/licenses/TU-Berlin-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TU-Berlin-2.0.json
+++ b/data/licenses/TU-Berlin-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TermReadKey.json
+++ b/data/licenses/TermReadKey.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ThirdEye.json
+++ b/data/licenses/ThirdEye.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/TrustedQSL.json
+++ b/data/licenses/TrustedQSL.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/UCAR.json
+++ b/data/licenses/UCAR.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/UCL-1.0.json
+++ b/data/licenses/UCL-1.0.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/UMich-Merit.json
+++ b/data/licenses/UMich-Merit.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/UPL-1.0.json
+++ b/data/licenses/UPL-1.0.json
@@ -37,5 +37,11 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
   ]
 }

--- a/data/licenses/URT-RLE.json
+++ b/data/licenses/URT-RLE.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Ubuntu-font-1.0.json
+++ b/data/licenses/Ubuntu-font-1.0.json
@@ -36,5 +36,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unicode-3.0.json
+++ b/data/licenses/Unicode-3.0.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unicode-DFS-2015.json
+++ b/data/licenses/Unicode-DFS-2015.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unicode-DFS-2016.json
+++ b/data/licenses/Unicode-DFS-2016.json
@@ -45,5 +45,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unicode-TOU.json
+++ b/data/licenses/Unicode-TOU.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/UnixCrypt.json
+++ b/data/licenses/UnixCrypt.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unlicense-libtelnet.json
+++ b/data/licenses/Unlicense-libtelnet.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unlicense-libwhirlpool.json
+++ b/data/licenses/Unlicense-libwhirlpool.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Unlicense.json
+++ b/data/licenses/Unlicense.json
@@ -36,5 +36,13 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:public-domain",
+    "copyleft:none",
+    "domain:content",
+    "domain:data"
   ]
 }

--- a/data/licenses/VOSTROM.json
+++ b/data/licenses/VOSTROM.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/VSL-1.0.json
+++ b/data/licenses/VSL-1.0.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Vim.json
+++ b/data/licenses/Vim.json
@@ -36,5 +36,10 @@
     "disclose-source",
     "same-license"
   ],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/W3C-19980720.json
+++ b/data/licenses/W3C-19980720.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/W3C-20150513.json
+++ b/data/licenses/W3C-20150513.json
@@ -50,5 +50,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/W3C.json
+++ b/data/licenses/W3C.json
@@ -41,5 +41,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/WTFPL.json
+++ b/data/licenses/WTFPL.json
@@ -41,5 +41,10 @@
     "private-use"
   ],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Watcom-1.0.json
+++ b/data/licenses/Watcom-1.0.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Widget-Workshop.json
+++ b/data/licenses/Widget-Workshop.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Wsuipa.json
+++ b/data/licenses/Wsuipa.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/X11-distribute-modifications-variant.json
+++ b/data/licenses/X11-distribute-modifications-variant.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/X11-swapped.json
+++ b/data/licenses/X11-swapped.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/X11.json
+++ b/data/licenses/X11.json
@@ -28,5 +28,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/XFree86-1.1.json
+++ b/data/licenses/XFree86-1.1.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/XSkat.json
+++ b/data/licenses/XSkat.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Xdebug-1.03.json
+++ b/data/licenses/Xdebug-1.03.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Xerox.json
+++ b/data/licenses/Xerox.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Xfig.json
+++ b/data/licenses/Xfig.json
@@ -45,5 +45,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Xnet.json
+++ b/data/licenses/Xnet.json
@@ -27,5 +27,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/YPL-1.0.json
+++ b/data/licenses/YPL-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/YPL-1.1.json
+++ b/data/licenses/YPL-1.1.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ZPL-1.1.json
+++ b/data/licenses/ZPL-1.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ZPL-2.0.json
+++ b/data/licenses/ZPL-2.0.json
@@ -36,5 +36,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ZPL-2.1.json
+++ b/data/licenses/ZPL-2.1.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zed.json
+++ b/data/licenses/Zed.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zeeff.json
+++ b/data/licenses/Zeeff.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zend-2.0.json
+++ b/data/licenses/Zend-2.0.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zimbra-1.3.json
+++ b/data/licenses/Zimbra-1.3.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zimbra-1.4.json
+++ b/data/licenses/Zimbra-1.4.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/Zlib.json
+++ b/data/licenses/Zlib.json
@@ -47,5 +47,12 @@
   "limitations": [
     "liability",
     "warranty"
+  ],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
   ]
 }

--- a/data/licenses/any-OSI-perl-modules.json
+++ b/data/licenses/any-OSI-perl-modules.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/any-OSI.json
+++ b/data/licenses/any-OSI.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/bcrypt-Solar-Designer.json
+++ b/data/licenses/bcrypt-Solar-Designer.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/blessing.json
+++ b/data/licenses/blessing.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/bzip2-1.0.5.json
+++ b/data/licenses/bzip2-1.0.5.json
@@ -38,5 +38,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/bzip2-1.0.6.json
+++ b/data/licenses/bzip2-1.0.6.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/check-cvs.json
+++ b/data/licenses/check-cvs.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/checkmk.json
+++ b/data/licenses/checkmk.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/copyleft-next-0.3.0.json
+++ b/data/licenses/copyleft-next-0.3.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/copyleft-next-0.3.1.json
+++ b/data/licenses/copyleft-next-0.3.1.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/curl.json
+++ b/data/licenses/curl.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/cve-tou.json
+++ b/data/licenses/cve-tou.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/diffmark.json
+++ b/data/licenses/diffmark.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/dtoa.json
+++ b/data/licenses/dtoa.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/dvipdfm.json
+++ b/data/licenses/dvipdfm.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/eCos-2.0.json
+++ b/data/licenses/eCos-2.0.json
@@ -29,5 +29,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/eGenix.json
+++ b/data/licenses/eGenix.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/etalab-2.0.json
+++ b/data/licenses/etalab-2.0.json
@@ -37,5 +37,12 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:government-open-license",
+    "domain:data",
+    "domain:content",
+    "notes:government-open-license",
+    "notes:attribution-required"
+  ]
 }

--- a/data/licenses/fwlw.json
+++ b/data/licenses/fwlw.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/gSOAP-1.3b.json
+++ b/data/licenses/gSOAP-1.3b.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/generic-xts.json
+++ b/data/licenses/generic-xts.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/gnuplot.json
+++ b/data/licenses/gnuplot.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/gtkbook.json
+++ b/data/licenses/gtkbook.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/hdparm.json
+++ b/data/licenses/hdparm.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/iMatix.json
+++ b/data/licenses/iMatix.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/jove.json
+++ b/data/licenses/jove.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/libpng-1.6.35.json
+++ b/data/licenses/libpng-1.6.35.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/libpng-2.0.json
+++ b/data/licenses/libpng-2.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/libselinux-1.0.json
+++ b/data/licenses/libselinux-1.0.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/libtiff.json
+++ b/data/licenses/libtiff.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/libutil-David-Nugent.json
+++ b/data/licenses/libutil-David-Nugent.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/lsof.json
+++ b/data/licenses/lsof.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/magaz.json
+++ b/data/licenses/magaz.json
@@ -37,5 +37,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/mailprio.json
+++ b/data/licenses/mailprio.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/man2html.json
+++ b/data/licenses/man2html.json
@@ -47,5 +47,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/metamail.json
+++ b/data/licenses/metamail.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/mpi-permissive.json
+++ b/data/licenses/mpi-permissive.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/mpich2.json
+++ b/data/licenses/mpich2.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/mplus.json
+++ b/data/licenses/mplus.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ngrep.json
+++ b/data/licenses/ngrep.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/pkgconf.json
+++ b/data/licenses/pkgconf.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/pnmstitch.json
+++ b/data/licenses/pnmstitch.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/psfrag.json
+++ b/data/licenses/psfrag.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/psutils.json
+++ b/data/licenses/psutils.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/python-ldap.json
+++ b/data/licenses/python-ldap.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/radvd.json
+++ b/data/licenses/radvd.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/snprintf.json
+++ b/data/licenses/snprintf.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/softSurfer.json
+++ b/data/licenses/softSurfer.json
@@ -35,5 +35,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ssh-keyscan.json
+++ b/data/licenses/ssh-keyscan.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/swrule.json
+++ b/data/licenses/swrule.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/threeparttable.json
+++ b/data/licenses/threeparttable.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/ulem.json
+++ b/data/licenses/ulem.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/w3m.json
+++ b/data/licenses/w3m.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/wwl.json
+++ b/data/licenses/wwl.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/wxWindows.json
+++ b/data/licenses/wxWindows.json
@@ -28,5 +28,11 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:osi-approved",
+    "spdx:deprecated",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/xinetd.json
+++ b/data/licenses/xinetd.json
@@ -26,5 +26,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "spdx:fsf-free",
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/xkeyboard-config-Zinoviev.json
+++ b/data/licenses/xkeyboard-config-Zinoviev.json
@@ -27,5 +27,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/xlock.json
+++ b/data/licenses/xlock.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/xpp.json
+++ b/data/licenses/xpp.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/xzoom.json
+++ b/data/licenses/xzoom.json
@@ -25,5 +25,9 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software"
+  ]
 }

--- a/data/licenses/zlib-acknowledgement.json
+++ b/data/licenses/zlib-acknowledgement.json
@@ -25,5 +25,10 @@
   "categorized": false,
   "permissions": [],
   "conditions": [],
-  "limitations": []
+  "limitations": [],
+  "tags": [
+    "license:open-source",
+    "domain:software",
+    "copyleft:permissive"
+  ]
 }

--- a/data/tags.json
+++ b/data/tags.json
@@ -1,0 +1,198 @@
+{
+  "license": {
+    "_group": {
+      "short": "License type",
+      "description": "High-level classification of the license family or ecosystem (e.g., Creative Commons, Open Data Commons, government open licenses, open-source, public domain, proprietary)."
+    },
+    "creative-commons": {
+      "description": "Licenses published by Creative Commons, typically used for content or data.",
+      "url": "https://creativecommons.org/licenses/"
+    },
+    "open-data-commons": {
+      "description": "Licenses from the Open Data Commons (ODC), including ODbL, ODC-By, and PDDL.",
+      "url": "https://opendatacommons.org/licenses/"
+    },
+    "government-open-license": {
+      "description": "Licenses published by governments for open data access, such as OGL-UK or Etalab.",
+      "url": "https://en.wikipedia.org/wiki/Open_government_licence"
+    },
+    "open-source": {
+      "description": "Standard open-source software licenses commonly used for software projects.",
+      "url": "https://opensource.org/licenses"
+    },
+    "public-domain": {
+      "description": "Licenses or statements that place the work in the public domain, such as CC0 or the Unlicense.",
+      "url": "https://creativecommons.org/share-your-work/public-domain/cc0/"
+    },
+    "proprietary": {
+      "description": "Licenses that impose significant restrictions and are not considered open.",
+      "url": null
+    }
+  },
+
+  "domain": {
+    "_group": {
+      "short": "Usage domain",
+      "description": "Describes the primary type of material the license is intended for, such as software, data, content, or documentation."
+    },
+    "software": {
+      "description": "Primarily applicable to software or source code.",
+      "url": null
+    },
+    "data": {
+      "description": "Primarily applicable to data sets or databases.",
+      "url": null
+    },
+    "content": {
+      "description": "Primarily applicable to creative works such as text, images, audio, or video.",
+      "url": null
+    },
+    "documentation": {
+      "description": "Primarily used for documentation, manuals, and written guides.",
+      "url": null
+    },
+    "mixed": {
+      "description": "Applies across multiple domains such as software, data, and content.",
+      "url": null
+    }
+  },
+
+  "copyleft": {
+    "_group": {
+      "short": "Copyleft strength",
+      "description": "Describes how strongly the license requires sharing modifications or derivative works under similar terms (permissive, weak copyleft, strong copyleft, network copyleft, or none)."
+    },
+    "permissive": {
+      "description": "Licenses allowing reuse with minimal restrictions, e.g., MIT, BSD, Apache.",
+      "url": "https://en.wikipedia.org/wiki/Permissive_software_licence"
+    },
+    "weak": {
+      "description": "Copyleft applies only to certain parts or files, e.g., MPL, LGPL.",
+      "url": "https://en.wikipedia.org/wiki/Weak_copyleft"
+    },
+    "strong": {
+      "description": "Copyleft requires that derivative works use the same license, e.g., GPL.",
+      "url": "https://en.wikipedia.org/wiki/Copyleft"
+    },
+    "network": {
+      "description": "Copyleft obligations also apply when the software is used over a network, e.g., AGPL.",
+      "url": "https://en.wikipedia.org/wiki/Affero_General_Public_License"
+    },
+    "none": {
+      "description": "No copyleft requirements (often public domain or very simple grants).",
+      "url": null
+    }
+  },
+
+  "family": {
+    "_group": {
+      "short": "License family",
+      "description": "Groups licenses that belong to the same legal family or brand, such as Creative Commons (CC), GPL, MIT, or Apache."
+    },
+    "CC": {
+      "description": "Creative Commons family, such as CC-BY, CC-BY-SA, etc.",
+      "url": "https://creativecommons.org/licenses/"
+    },
+    "ODC": {
+      "description": "Open Data Commons license family, including ODbL, ODC-By, and PDDL.",
+      "url": "https://opendatacommons.org/licenses/"
+    },
+    "GPL": {
+      "description": "GNU General Public License family.",
+      "url": "https://www.gnu.org/licenses/gpl-3.0.html"
+    },
+    "AGPL": {
+      "description": "GNU Affero General Public License family.",
+      "url": "https://www.gnu.org/licenses/agpl-3.0.html"
+    },
+    "LGPL": {
+      "description": "GNU Lesser General Public License family.",
+      "url": "https://www.gnu.org/licenses/lgpl-3.0.html"
+    },
+    "MIT": {
+      "description": "MIT permissive license family.",
+      "url": "https://opensource.org/license/mit/"
+    },
+    "BSD": {
+      "description": "BSD 2-Clause and 3-Clause permissive license family.",
+      "url": "https://opensource.org/licenses/BSD-3-Clause"
+    },
+    "Apache": {
+      "description": "Apache License family, including Apache-1.1 and Apache-2.0.",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  },
+
+  "region": {
+    "_group": {
+      "short": "Region or jurisdiction",
+      "description": "Indicates that a license is specific to a country or jurisdiction, such as UK, Norway, or France."
+    },
+    "UK": {
+      "description": "United Kingdom localized or government licenses (for example, OGL-UK).",
+      "url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    },
+    "NO": {
+      "description": "Norwegian government licenses (for example, NLOD).",
+      "url": "https://data.norge.no/nlod/en"
+    },
+    "FR": {
+      "description": "French government open data licenses (for example, Licence Ouverte / Etalab).",
+      "url": "https://www.etalab.gouv.fr/licence-ouverte-open-licence/"
+    }
+  },
+
+  "notes": {
+    "_group": {
+      "short": "Special behavior",
+      "description": "Additional semantic flags that describe important behavioral aspects of a license, such as attribution requirements, share-alike, or custom terms."
+    },
+    "attribution-required": {
+      "description": "License requires attribution to the original creator or data provider.",
+      "url": "https://en.wikipedia.org/wiki/Attribution_(copyright)"
+    },
+    "share-alike": {
+      "description": "Derivatives must be licensed under the same or a compatible license.",
+      "url": "https://creativecommons.org/share-your-work/how-to-attribute/sa/"
+    },
+    "no-derivatives": {
+      "description": "Users may not distribute derivative works.",
+      "url": "https://creativecommons.org/licenses/by-nd/4.0/"
+    },
+    "includes-patent-grant": {
+      "description": "The license includes an explicit grant of patent rights to downstream users.",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0#patent"
+    },
+    "must-include-disclaimer": {
+      "description": "The license requires including a disclaimer of warranties or liability.",
+      "url": "https://en.wikipedia.org/wiki/Warranty_disclaimer"
+    },
+    "government-open-license": {
+      "description": "Indicates the license is a government open license with special terms or obligations.",
+      "url": "https://en.wikipedia.org/wiki/Open_government_licence"
+    },
+    "custom-terms": {
+      "description": "The license contains custom, non-standard, or unusual terms not fully covered by other tags.",
+      "url": null
+    }
+  },
+
+  "spdx": {
+    "_group": {
+      "short": "SPDX status",
+      "description": "Metadata that reflects how the license is classified in the SPDX list, such as OSI approval, FSF status, or deprecation."
+    },
+    "osi-approved": {
+      "description": "The license is approved by the Open Source Initiative (OSI).",
+      "url": "https://opensource.org/licenses"
+    },
+    "fsf-free": {
+      "description": "The license is classified as free by the Free Software Foundation.",
+      "url": "https://www.gnu.org/licenses/license-list.html"
+    },
+    "deprecated": {
+      "description": "This license identifier is deprecated in the SPDX list and should not be used for new content.",
+      "url": "https://spdx.org/licenses/"
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -93,8 +93,6 @@ Outputs:
 - Conditions
 - Limitations
 
----
-
 ### Dependencies
 
 Install the required Python packages:
@@ -102,3 +100,28 @@ Install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
+
+---
+
+## License Tagging Utility
+
+### `licenses_tags.py`
+
+The `licenses_tags.py` script is used to apply tags to license JSON files in the `data/licenses/` directory. Tags provide metadata about licenses, such as their permissions, conditions, limitations, and domains of applicability. This script ensures consistency and accuracy by validating tags against a predefined tag registry.
+
+### Output
+
+Each license JSON file is updated with a `tags` field, which contains a list of tags describing the license. Tags are categorized into the following groups:
+
+- **License Type**: e.g., `license:public-domain`, `license:open-source`, `license:creative-commons`.
+- **Domain**: e.g., `domain:content`, `domain:data`, `domain:software`.
+- **Copyleft Strength**: e.g., `copyleft:none`, `copyleft:weak`, `copyleft:strong`.
+- **Family**: e.g., `family:CC` (Creative Commons), `family:GPL` (GNU General Public License).
+- **Notes**: e.g., `notes:attribution-required`, `notes:share-alike`.
+
+### Usage
+
+Run the script from the repository root:
+
+```bash
+python licenses_tags.py

--- a/scripts/licenses_tags.py
+++ b/scripts/licenses_tags.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python
+#!/usr/bin/env python
+"""
+licenses_tags.py
+
+This script applies tag heuristics to license JSON files in the `data/licenses/` directory.
+Tags provide metadata about licenses, such as their permissions, restrictions, and domains
+of applicability. The script validates tags against a tag registry (`data/tags.json`) and
+updates the `tags` field in each license JSON file.
+
+Usage:
+    python licenses_tags.py [--only-missing]
+
+Options:
+    --only-missing    Only add tags to files that do not already have a `tags` field.
+
+Features:
+- **Tag Generation**: Automatically generates tags for licenses based on their SPDX ID and metadata.
+- **Validation**: Ensures generated tags are valid according to the tag registry.
+- **Heuristics**: Applies predefined rules to assign tags based on license characteristics.
+
+Tagging Categories:
+- **License Type**: e.g., `license:public-domain`, `license:open-source`, `license:creative-commons`.
+- **Domain**: e.g., `domain:content`, `domain:data`, `domain:software`.
+- **Copyleft Strength**: e.g., `copyleft:none`, `copyleft:weak`, `copyleft:strong`.
+- **Family**: e.g., `family:CC` (Creative Commons), `family:GPL` (GNU General Public License).
+- **Notes**: e.g., `notes:attribution-required`, `notes:share-alike`.
+
+Dependencies:
+- Python 3.8+
+- `data/tags.json`: The tag registry file containing valid tags and their metadata.
+
+Examples:
+1. Apply tags to all license files:
+    python licenses_tags.py
+
+2. Apply tags only to files missing the `tags` field:
+    python licenses_tags.py --only-missing
+
+Notes:
+- Public domain licenses (e.g., `CC0-1.0`, `UNLICENSE`) are tagged as `license:public-domain` and apply to both `domain:content` and `domain:data`.
+- Creative Commons licenses (e.g., `CC-BY-4.0`) are tagged as `license:creative-commons` and may include additional notes like `notes:attribution-required` or `notes:share-alike`.
+- Open Data Commons licenses (e.g., `ODBL`, `PDDL`) are tagged as `license:open-data-commons` and focus on `domain:data`.
+
+"""
+import json
+import argparse
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+LICENSES_DIR = BASE_DIR / "data" / "licenses"
+TAGS_JSON_PATH = BASE_DIR / "data" / "tags.json"
+
+
+# ---------- Tag Registry ----------
+
+class TagRegistry:
+    """
+    Loads the tag registry (data/tags.json) and validates tag keys of the form 'group:key'.
+
+    Each group (e.g. 'license', 'domain') can contain:
+      - a special '_group' entry with {short, description}
+      - tag keys (e.g. 'creative-commons') with {description, url}
+    """
+
+    def __init__(self, path: Path):
+        with path.open("r", encoding="utf-8") as f:
+            self.registry: Dict[str, Dict[str, Any]] = json.load(f)
+
+    def is_valid(self, tag: str) -> bool:
+        group, _, key = tag.partition(":")
+        if not group or not key:
+            return False
+        group_dict = self.registry.get(group)
+        if not isinstance(group_dict, dict):
+            return False
+        # '_group' is reserved metadata, not an actual tag key
+        if key == "_group":
+            return False
+        return key in group_dict
+
+    def get_group_meta(self, group: str) -> Optional[Dict[str, Any]]:
+        """
+        Return the metadata (short, description) for a tag group, if available.
+        Useful for UI rendering.
+        """
+        group_dict = self.registry.get(group)
+        if not isinstance(group_dict, dict):
+            return None
+        meta = group_dict.get("_group")
+        if isinstance(meta, dict):
+            return meta
+        return None
+
+    def get_tag_info(self, tag: str) -> Optional[Dict[str, Any]]:
+        """
+        Return the full info for a specific tag (description, url) if it exists.
+        """
+        group, _, key = tag.partition(":")
+        group_dict = self.registry.get(group)
+        if not isinstance(group_dict, dict):
+            return None
+        info = group_dict.get(key)
+        if isinstance(info, dict):
+            return info
+        return None
+
+
+# ---------- Tag Heuristics ----------
+
+def build_tags(spdx_id: str, spdx_info: Dict[str, Any]) -> List[str]:
+    """
+    Build raw tag list (strings) for a given SPDX ID using heuristics.
+    A license MAY receive multiple tags from the same group
+    (for example domain:content AND domain:data).
+    Validation against TagRegistry is done separately.
+    """
+    tags: List[str] = []
+    sid = spdx_id.upper()
+
+    osi = bool(spdx_info.get("isOsiApproved"))
+    fsf = bool(spdx_info.get("isFsfLibre"))
+    deprecated = bool(spdx_info.get("isDeprecatedLicenseId"))
+
+    # SPDX status tags
+    if osi:
+        tags.append("spdx:osi-approved")
+    if fsf:
+        tags.append("spdx:fsf-free")
+    if deprecated:
+        tags.append("spdx:deprecated")
+
+    # --- Public domain / PD-like licenses ---
+    # These can be safely used for BOTH content and data,
+    # and have no copyleft obligations at all.
+    PUBLIC_DOMAIN = {"CC0-1.0", "UNLICENSE", "0BSD"}
+    if sid in PUBLIC_DOMAIN:
+        tags += [
+            "license:public-domain",
+            "copyleft:none",
+            "domain:content",
+            "domain:data",
+        ]
+        return tags
+
+    # --- Creative Commons ---
+    if sid.startswith("CC-"):
+        tags += [
+            "license:creative-commons",
+            "family:CC",
+            "domain:content",  # CC is content-first by design
+        ]
+
+        # Attribution + ShareAlike notes
+        if "-BY-" in sid:
+            tags.append("notes:attribution-required")
+        if "-SA-" in sid:
+            tags.append("notes:share-alike")
+
+        # CC-BY / CC-BY-SA 4.0 are widely used for data as well.
+        # We allow dual-domain tagging here.
+        if sid.startswith(("CC-BY-", "CC-BY-SA-")) and sid.endswith("-4.0"):
+            tags.append("domain:data")
+
+        return tags
+
+    # --- Open Data Commons (data-focused) ---
+    if sid.startswith(("ODBL", "ODC-", "PDDL")):
+        tags += [
+            "license:open-data-commons",
+            "family:ODC",
+            "domain:data",
+        ]
+        # ODbL and ODC-By strongly encourage attribution and share-alike
+        if sid.startswith(("ODBL", "ODC-BY")):
+            tags.append("notes:attribution-required")
+            tags.append("notes:share-alike")
+        # PDDL is public-domain-like for data, but we still treat it as data-centric
+        return tags
+
+    # --- Government open licenses ---
+    if sid.startswith(("OGL-", "NLOD-", "ETALAB-")):
+        # Government open licenses often cover BOTH published reports (content)
+        # and open data files (data), so we tag them as dual-domain.
+        tags += [
+            "license:government-open-license",
+            "domain:data",
+            "domain:content",
+            "notes:government-open-license",
+            "notes:attribution-required",
+        ]
+        return tags
+
+    # --- GPL family ---
+    if sid.startswith("GPL-"):
+        tags += [
+            "license:open-source",
+            "family:GPL",
+            "domain:software",
+            "copyleft:strong",
+        ]
+        return tags
+
+    # --- AGPL ---
+    if sid.startswith("AGPL-"):
+        tags += [
+            "license:open-source",
+            "family:AGPL",
+            "domain:software",
+            "copyleft:network",
+        ]
+        return tags
+
+    # --- LGPL ---
+    if sid.startswith("LGPL-"):
+        tags += [
+            "license:open-source",
+            "family:LGPL",
+            "domain:software",
+            "copyleft:weak",
+        ]
+        return tags
+
+    # --- Weak copyleft: MPL, EPL, CDDL ---
+    if sid.startswith(("MPL-", "EPL-", "CDDL-")):
+        tags += [
+            "license:open-source",
+            "domain:software",
+            "copyleft:weak",
+        ]
+        return tags
+
+    # --- Documentation-oriented licenses (GFDL etc.) ---
+    if sid.startswith("GFDL-"):
+        # GFDL is mainly for documentation / manuals,
+        # but that content is still expressive content.
+        tags += [
+            "license:open-source",
+            "domain:documentation",
+            "domain:content",
+        ]
+        return tags
+
+    # --- Permissive licenses: MIT, BSD, Apache, ISC, Zlib ---
+    if sid.startswith(("MIT", "BSD-", "APACHE-", "ISC", "ZLIB")):
+        tags += [
+            "license:open-source",
+            "domain:software",
+            "copyleft:permissive",
+        ]
+        return tags
+
+    # --- Default fallback for unknown OSS-y licenses ---
+    tags += [
+        "license:open-source",
+        "domain:software",
+    ]
+    return tags
+
+
+def apply_tags_to_file(path: Path, registry: TagRegistry) -> None:
+    """
+    Load a single license JSON file, compute tags, and update the "tags" field.
+    Does not modify any other keys.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    spdx_info = data.get("spdx")
+    if not isinstance(spdx_info, dict):
+        # Nothing to do if SPDX info isn't present
+        return
+
+    spdx_id = spdx_info.get("licenseId")
+    if not spdx_id:
+        return
+
+    raw_tags = build_tags(spdx_id, spdx_info)
+    valid_tags = [t for t in raw_tags if registry.is_valid(t)]
+
+    data["tags"] = valid_tags
+
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+# ---------- CLI ----------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Apply tag heuristics to merged license JSON files (data/licenses/*.json)."
+    )
+    parser.add_argument(
+        "--only-missing",
+        action="store_true",
+        help="Only add tags to files that do not already have a 'tags' field.",
+    )
+    args = parser.parse_args()
+
+    if not TAGS_JSON_PATH.exists():
+        raise FileNotFoundError(f"Tag registry not found at {TAGS_JSON_PATH}")
+
+    registry = TagRegistry(TAGS_JSON_PATH)
+
+    for json_file in sorted(LICENSES_DIR.glob("*.json")):
+        if args.only_missing:
+            with json_file.open("r", encoding="utf-8") as f:
+                try:
+                    data = json.load(f)
+                except json.JSONDecodeError:
+                    continue
+            if "tags" in data:
+                # Skip files that already have tags
+                continue
+
+        apply_tags_to_file(json_file, registry)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Note to the reviewer
I understand that this is a 300+ file change; I can feel your pain. The reason is simple: this repo has the data of the licenses in it with the script. How _I_ think this PR can be humanly reviewed,
- Review file [data/tags.json](https://github.com/MobilityData/licenses-aas/blob/0d60af98a9c41639b1c78a278e9ca3448b53c7db/data/tags.json)
- Review file [licenses_tags.py](https://github.com/MobilityData/licenses-aas/blob/0d60af98a9c41639b1c78a278e9ca3448b53c7db/scripts/licenses_tags.py)
- Review README.md
- Pick a few license files and review them

## Description

This pull request adds standardized metadata tags to a variety of license JSON files in the `data/licenses` directory. The main purpose is to improve license classification and searchability by including tags for approval status, license type, domain, copyleft status, and family where appropriate.

# Tags Metadata Registry

The `tags.json` file is a structured metadata registry that defines tags for classifying and describing licenses. Tags are grouped into categories, each with a specific purpose, and include descriptions and optional URLs for additional context.

## Tag Groups

### 1. License Type
High-level classification of the license family or ecosystem (e.g., Creative Commons, Open Data Commons, public domain, proprietary).

| Tag                  | Description                                                                                     | URL                                                                 |
|----------------------|-------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
| `creative-commons`   | Licenses published by Creative Commons, typically used for content or data.                    | [Creative Commons](https://creativecommons.org/licenses/)          |
| `open-data-commons`  | Licenses from the Open Data Commons (ODC), including ODbL, ODC-By, and PDDL.                   | [Open Data Commons](https://opendatacommons.org/licenses/)         |
| `government-open-license` | Licenses published by governments for open data access, such as OGL-UK or Etalab.         | [Open Government License](https://en.wikipedia.org/wiki/Open_government_licence) |
| `open-source`        | Standard open-source software licenses commonly used for software projects.                    | [Open Source Licenses](https://opensource.org/licenses)            |
| `public-domain`      | Licenses or statements that place the work in the public domain, such as CC0 or the Unlicense. | [Public Domain](https://creativecommons.org/share-your-work/public-domain/cc0/) |
| `proprietary`        | Licenses that impose significant restrictions and are not considered open.                     | N/A                                                               |

---

### 2. Usage Domain
Describes the primary type of material the license is intended for, such as software, data, content, or documentation.

| Tag          | Description                                                   | URL |
|--------------|---------------------------------------------------------------|-----|
| `software`   | Primarily applicable to software or source code.              | N/A |
| `data`       | Primarily applicable to data sets or databases.               | N/A |
| `content`    | Primarily applicable to creative works such as text, images, audio, or video. | N/A |
| `documentation` | Primarily used for documentation, manuals, and written guides. | N/A |
| `mixed`      | Applies across multiple domains such as software, data, and content. | N/A |

---

### 3. Copyleft Strength
Describes how strongly the license requires sharing modifications or derivative works under similar terms.

| Tag          | Description                                                                 | URL                                                                 |
|--------------|-----------------------------------------------------------------------------|---------------------------------------------------------------------|
| `permissive` | Licenses allowing reuse with minimal restrictions, e.g., MIT, BSD, Apache. | [Permissive Licenses](https://en.wikipedia.org/wiki/Permissive_software_licence) |
| `weak`       | Copyleft applies only to certain parts or files, e.g., MPL, LGPL.          | [Weak Copyleft](https://en.wikipedia.org/wiki/Weak_copyleft)       |
| `strong`     | Copyleft requires that derivative works use the same license, e.g., GPL.   | [Strong Copyleft](https://en.wikipedia.org/wiki/Copyleft)          |
| `network`    | Copyleft obligations also apply when the software is used over a network, e.g., AGPL. | [Network Copyleft](https://en.wikipedia.org/wiki/Affero_General_Public_License) |
| `none`       | No copyleft requirements (often public domain or very simple grants).      | N/A                                                               |

---

### 4. License Family
Groups licenses that belong to the same legal family or brand.

| Tag      | Description                                                   | URL                                                                 |
|----------|---------------------------------------------------------------|---------------------------------------------------------------------|
| `CC`     | Creative Commons family, such as CC-BY, CC-BY-SA, etc.        | [Creative Commons](https://creativecommons.org/licenses/)          |
| `ODC`    | Open Data Commons license family, including ODbL, ODC-By, and PDDL. | [Open Data Commons](https://opendatacommons.org/licenses/)         |
| `GPL`    | GNU General Public License family.                            | [GPL](https://www.gnu.org/licenses/gpl-3.0.html)                   |
| `AGPL`   | GNU Affero General Public License family.                     | [AGPL](https://www.gnu.org/licenses/agpl-3.0.html)                 |
| `LGPL`   | GNU Lesser General Public License family.                     | [LGPL](https://www.gnu.org/licenses/lgpl-3.0.html)                 |
| `MIT`    | MIT permissive license family.                                | [MIT](https://opensource.org/license/mit/)                         |
| `BSD`    | BSD 2-Clause and 3-Clause permissive license family.          | [BSD](https://opensource.org/licenses/BSD-3-Clause)                |
| `Apache` | Apache License family, including Apache-1.1 and Apache-2.0.   | [Apache](https://www.apache.org/licenses/LICENSE-2.0)              |

---

### 5. Region or Jurisdiction
Indicates that a license is specific to a country or jurisdiction.

| Tag  | Description                                                   | URL                                                                 |
|------|---------------------------------------------------------------|---------------------------------------------------------------------|
| `UK` | United Kingdom localized or government licenses (e.g., OGL-UK). | [OGL-UK](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) |
| `NO` | Norwegian government licenses (e.g., NLOD).                   | [NLOD](https://data.norge.no/nlod/en)                              |
| `FR` | French government open data licenses (e.g., Licence Ouverte). | [Licence Ouverte](https://www.etalab.gouv.fr/licence-ouverte-open-licence/) |

---

### 6. Special Behavior
Additional semantic flags that describe important behavioral aspects of a license.

| Tag                     | Description                                                                 | URL                                                                 |
|-------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------------------|
| `attribution-required`  | License requires attribution to the original creator or data provider.      | [Attribution](https://en.wikipedia.org/wiki/Attribution_(copyright)) |
| `share-alike`           | Derivatives must be licensed under the same or a compatible license.        | [Share-Alike](https://creativecommons.org/share-your-work/how-to-attribute/sa/) |
| `no-derivatives`        | Users may not distribute derivative works.                                 | [No Derivatives](https://creativecommons.org/licenses/by-nd/4.0/)  |
| `includes-patent-grant` | The license includes an explicit grant of patent rights to downstream users. | [Patent Grant](https://www.apache.org/licenses/LICENSE-2.0#patent) |
| `must-include-disclaimer` | The license requires including a disclaimer of warranties or liability.   | [Disclaimer](https://en.wikipedia.org/wiki/Warranty_disclaimer)    |
| `custom-terms`          | The license contains custom, non-standard, or unusual terms.               | N/A                                                               |

---

### 7. SPDX Status
Metadata that reflects how the license is classified in the SPDX list.

| Tag           | Description                                                                 | URL                                                                 |
|---------------|-----------------------------------------------------------------------------|---------------------------------------------------------------------|
| `osi-approved` | The license is approved by the Open Source Initiative (OSI).              | [OSI Approved](https://opensource.org/licenses)                    |
| `fsf-free`    | The license is classified as free by the Free Software Foundation.          | [FSF Free](https://www.gnu.org/licenses/license-list.html)         |
| `deprecated`  | This license identifier is deprecated in the SPDX list and should not be used for new content. | [SPDX Deprecated](https://spdx.org/licenses/)                      |

---

This `tags.json` file ensures consistent tagging and validation of licenses, enabling structured classification and metadata management.

## From our AI friend

**License metadata enhancements:**

* Added tags such as `spdx:osi-approved`, `spdx:fsf-free`, `license:open-source`, `domain:software`, and `copyleft:network` to AGPL licenses (`AGPL-1.0-only.json`, `AGPL-1.0-or-later.json`, `AGPL-1.0.json`, `AGPL-3.0-only.json`, `AGPL-3.0-or-later.json`, `AGPL-3.0.json`). [[1]](diffhunk://#diff-7b96025d245fdef57b43e1cab6f13d47b51cc9192ec9b89d7ea072cd90d0ef3bL28-R34) [[2]](diffhunk://#diff-acc91fa7a1b5d7f36420a1d6cc86191ac009a3d78a750eb9aeefe94ba66823d7L30-R36) [[3]](diffhunk://#diff-0e0157ac79bb46b9e7be319e334918717f61ca78ca0c097f5b4b004d1c800f7fL32-R40) [[4]](diffhunk://#diff-ea1a243f10d2fd124651414977d1847cce3bbafaff9f6215bb8db3226a927c85L44-R52) [[5]](diffhunk://#diff-1e234e55611d92088e36ccdb28a1441c849ac100c47e7f8df1061990eb59f1ebL44-R52) [[6]](diffhunk://#diff-e507f8643a0f6134209875f7ad4626937dd189221db1ab7ebfd1eda255a24915R58-R66)
* Added tags for approval status and domain to AFL licenses (`AFL-1.1.json`, `AFL-1.2.json`, `AFL-2.0.json`, `AFL-2.1.json`, `AFL-3.0.json`). [[1]](diffhunk://#diff-f18723ca25f5783dcf8d5a9ee226f59b96df6b1c249ea096ce7f79ad4c0a7380L44-R50) [[2]](diffhunk://#diff-c07ffd0c08b0a2725ea0ac89aa174ffc80a44169e2b189606b34120397398cf8L44-R50) [[3]](diffhunk://#diff-8d086262d2575bc8fed98e9aecdd5486b019513cc8513f1cba614a06f574f5dbL32-R38) [[4]](diffhunk://#diff-e3817de2ab41980dc61e4769a33d4e29a0a9208c5d1d1915166537f3ff96804cL32-R38) [[5]](diffhunk://#diff-f89c84ddf500261e5768ec2d470b6fca0a39780d78f5da20b7e180e9a014fcedR55-R60)
* Added tags for open-source status and domain to various other licenses (`3D-Slicer-1.0.json`, `AAL.json`, `ADSL.json`, `AMD-newlib.json`, `AMDPLPA.json`, `AML-glslang.json`, `AML.json`, `AMPAS.json`). [[1]](diffhunk://#diff-14d0e57e361ba41975e0bcd14e9954f0e2eba9b9bb835856aa0a1a5ac9d627cdL38-R42) [[2]](diffhunk://#diff-7b2cc06a2da542ebb13a22234201825001f20a9e9fde95881cbc8bc89505940cL30-R35) [[3]](diffhunk://#diff-df4a625ec60ee148ec8bda5fc838cf180fc8868c31f45f718ee709253225bc3dL28-R32) [[4]](diffhunk://#diff-e4cb65ce603ea60c00d4be07a48c58d3027467ec59d59d8329959b390fcee80fL28-R32) [[5]](diffhunk://#diff-1d5825a800ef17ae3bae750f72b6bd56e58f75674db85e5c1d75a6e56408e79bL28-R32) [[6]](diffhunk://#diff-9e4888bcb1b7d313db7219170228d3f06cc2a17c1f82ce465258546beb16e04dL38-R42) [[7]](diffhunk://#diff-5ef98a5c1929c581119af31795193f2d52cdd3ea2ef6adc4d293e69f59e66665L28-R32) [[8]](diffhunk://#diff-3e1e12a6ed809cafb474f41fe041c92108cdb3e4f4174cab2b1cf038e4f84633L28-R32)
* Added public domain and content/data domain tags to `0BSD.json`.