### PR TITLE
fix: Python release workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/licenses-aas/
+      url: https://pypi.org/project/licenses-catalog/
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main, master ]
   pull_request:
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
# Description
This pull request updates GitHub Actions workflows to improve CI/CD integration for the Python project. The main changes involve updating the release environment URL and enabling workflow reusability.

**Workflow improvements:**

* Updated the PyPI environment URL in `.github/workflows/python-release.yml` to point to the new `licenses-catalog` project, reflecting a change in the package name or repository.
* Added `workflow_call` to the triggers in `.github/workflows/python-test.yml`, allowing this workflow to be invoked by other workflows, which improves modularity and reusability in CI/CD pipelines.