### PR TITLE
lic: add license etalab 2.0 rules

### DIFF
--- a/data/licenses/etalab-2.0.json
+++ b/data/licenses/etalab-2.0.json
@@ -35,14 +35,75 @@
     "licenseTextHtml": "\n\n      <div class=\"optional-license-text\"> \n            <p>LICENCE OUVERTE / OPEN LICENCE</p>\n\n            <div class=\"optional-license-text\"> <p>===================================================================</p>\n</div>\n\n            <p>- Version 2.0</p>\n\n            <p>- Avril 2017</p>\n\n      </div>\n\n    <p>« RÉUTILISATION » DE L&apos;« INFORMATION » SOUS CETTE LICENCE</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>Le « Concédant » concède au « Réutilisateur » un droit non exclusif et gratuit\n    de libre « Réutilisation » de l&apos;« Information » objet de la présente licence,\n    à des fins commerciales ou non, dans le monde entier et pour une durée\n    illimitée, dans les conditions exprimées ci-dessous.</p>\n\n    <p>Le « Réutilisateur » est libre de réutiliser l&apos;« Information » :</p>\n\n<ul style=\"list-style:none\">\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> de la reproduire, la copier,</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> de l&apos;adapter, la modifier, l&apos;extraire et la transformer, pour créer des « Informations dérivées », des produits ou des services,</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> de la communiquer, la diffuser, la redistribuer, la publier et la transmettre,</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> de l&apos;exploiter à titre commercial, par exemple en la combinant avec d&apos;autres informations, ou en l&apos;incluant dans son propre produit ou application.</li>\n    \n</ul>\n\n    <p>Sous réserve de :</p>\n\n<ul style=\"list-style:none\">\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> mentionner la paternité de l&apos;« Information » : sa source (au moins le nom du « Concédant ») et la date de dernière mise à jour de l&apos;« Information » réutilisée.</li>\n    \n</ul>\n\n    <p>Le « Réutilisateur » peut notamment s&apos;acquitter de cette condition en renvoyant,\n    par un lien hypertexte, vers la source de « l&apos;Information » et assurant une\n    mention effective de sa paternité.</p>\n\n    <p>Par exemple :</p>\n\n    <p>« Ministère de xxx - Données originales téléchargées sur\n    http://www.data.gouv.fr/fr/datasets/xxx/, mise à jour du 14 février 2017 ».</p>\n\n    <p>Cette mention de paternité ne confère aucun caractère officiel à la\n    « Réutilisation » de l&apos;« Information », et ne doit pas suggérer une quelconque\n    reconnaissance ou caution par le « Concédant », ou par toute autre entité\n    publique, du « Réutilisateur » ou de sa « Réutilisation ».</p>\n\n    <p>« DONNÉES À CARACTÈRE PERSONNEL »</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>L&apos;« Information » mise à disposition peut contenir des « Données à caractère\n    personnel » pouvant faire l&apos;objet d&apos;une « Réutilisation ». Si tel est le cas,\n    le « Concédant » informe le « Réutilisateur » de leur présence.</p>\n\n    <p>L&apos;« Information » peut être librement réutilisée, dans le cadre des droits\n    accordés par la présente licence, à condition de respecter le cadre légal\n    relatif à la protection des données à caractère personnel.</p>\n\n    <p>« DROITS DE PROPRIÉTÉ INTELLECTUELLE »</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>Il est garanti au « Réutilisateur » que les éventuels « Droits de propriété\n    intellectuelle » détenus par des tiers ou par le « Concédant » sur\n    l&apos;« Information » ne font pas obstacle aux droits accordés par la présente\n    licence.</p>\n\n    <p>Lorsque le « Concédant » détient des « Droits de propriété intellectuelle »\n    cessibles sur l&apos;« Information », il les cède au « Réutilisateur » de façon non\n    exclusive, à titre gracieux, pour le monde entier, pour toute la durée des\n    « Droits de propriété intellectuelle », et le « Réutilisateur » peut faire tout\n    usage de l&apos;« Information » conformément aux libertés et aux conditions définies\n    par la présente licence.</p>\n\n    <p>RESPONSABILITÉ</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>L&apos;« Information » est mise à disposition telle que produite ou reçue par le\n    « Concédant », sans autre garantie expresse ou tacite que celles prévues par la\n    présente licence. L&apos;absence de défauts ou d&apos;erreurs éventuellement contenues\n    dans l&apos;« Information », comme la fourniture continue de l&apos;« Information » n&apos;est\n    pas garantie par le « Concédant ». Il ne peut être tenu pour responsable de\n    toute perte, préjudice ou dommage de quelque sorte causé à des tiers du fait de\n    la « Réutilisation ».</p>\n\n    <p>Le « Réutilisateur » est seul responsable de la « Réutilisation » de\n    l&apos;« Information ».</p>\n\n    <p>La « Réutilisation » ne doit pas induire en erreur des tiers quant au contenu\n    de l&apos;« Information », sa source et sa date de mise à jour.</p>\n\n    <p>DROIT APPLICABLE</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>La présente licence est régie par le droit français.</p>\n\n    <p>COMPATIBILITÉ DE LA PRÉSENTE LICENCE</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>La présente licence a été conçue pour être compatible avec toute licence libre\n    qui exige au moins la mention de paternité et notamment avec la version\n    antérieure de la présente licence ainsi qu&apos;avec les licences :</p>\n\n<ul style=\"list-style:none\">\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> « Open Government Licence » (OGL) du Royaume-Uni,</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> « Creative Commons Attribution » (CC-BY) de Creative Commons et</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> « Open Data Commons Attribution » (ODC-BY) de l&apos;Open Knowledge Foundation.</li>\n    \n</ul>\n\n    <p>DÉFINITIONS</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>Sont considérés, au sens de la présente licence comme :</p>\n\n    <p>Le « Concédant » : toute personne concédant un droit de « Réutilisation » sur\n    l&apos;« Information » dans les libertés et les conditions prévues par la présente\n    licence</p>\n\n    <p>L&apos;« Information » :</p>\n\n<ul style=\"list-style:none\">\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> toute information publique figurant dans des documents communiqués ou publiés par une administration mentionnée au premier alinéa de l&apos;article L.300-2 du CRPA;</li>\n        \n<li><var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> -</span></var> toute information mise à disposition par toute personne selon les termes et conditions de la présente licence.</li>\n    \n</ul>\n\n    <p>La « Réutilisation » : l&apos;utilisation de l&apos;« Information » à d&apos;autres fins que\n    celles pour lesquelles elle a été produite ou reçue.</p>\n\n    <p>Le « Réutilisateur »: toute personne qui réutilise les « Informations »\n    conformément aux conditions de la présente licence.</p>\n\n    <p>Des « Données à caractère personnel » : toute information se rapportant à une\n    personne physique identifiée ou identifiable, pouvant être identifiée\n    directement ou indirectement. Leur « Réutilisation » est subordonnée au respect\n    du cadre juridique en vigueur.</p>\n\n    <p>Une « Information dérivée » : toute nouvelle donnée ou information créées\n    directement à partir de l&apos;« Information » ou à partir d&apos;une combinaison de\n    l&apos;« Information » et d&apos;autres données ou informations non soumises à cette\n    licence.</p>\n\n    <p>Les « Droits de propriété intellectuelle » : tous droits identifiés comme tels\n    par le Code de la propriété intellectuelle (notamment le droit d&apos;auteur, droits\n    voisins au droit d&apos;auteur, droit sui generis des producteurs de bases de\n    données…).</p>\n\n    <p>À PROPOS DE CETTE LICENCE</p>\n\n    <div class=\"optional-license-text\"> <p>-------------------------------------------------------------------</p>\n</div>\n\n    <p>La présente licence a vocation à être utilisée par les administrations pour la\n    réutilisation de leurs informations publiques. Elle peut également être\n    utilisée par toute personne souhaitant mettre à disposition de\n    l&apos;« Information » dans les conditions définies par la présente licence.</p>\n\n    <p>La France est dotée d&apos;un cadre juridique global visant à une diffusion\n    spontanée par les administrations de leurs informations publiques afin d&apos;en\n    permettre la plus large réutilisation.</p>\n\n    <p>Le droit de la « Réutilisation » de l&apos;« Information » des administrations est\n    régi par le code des relations entre le public et l&apos;administration (CRPA).</p>\n\n    <p>Cette licence facilite la réutilisation libre et gratuite des informations\n    publiques et figure parmi les licences qui peuvent être utilisées par\n    l&apos;administration en vertu du décret pris en application de l&apos;article L.323-2\n    du CRPA.</p>\n\n    <p>Etalab est la mission chargée, sous l&apos;autorité du Premier ministre, d&apos;ouvrir le\n    plus grand nombre de données publiques des administrations de l&apos;Etat et de ses\n    établissements publics. Elle a réalisé la Licence Ouverte pour faciliter la\n    réutilisation libre et gratuite de ces informations publiques, telles que\n    définies par l&apos;article L321-1 du CRPA.</p>\n\n    <p>Cette licence est la version 2.0 de la Licence Ouverte.</p>\n\n    <p>Etalab se réserve la faculté de proposer de nouvelles versions de la Licence\n    Ouverte. Cependant, les « Réutilisateurs » pourront continuer à réutiliser les\n    informations qu&apos;ils ont obtenues sous cette licence s&apos;ils le souhaitent.</p>\n\n    "
   },
   "categorized": false,
-  "permissions": [],
-  "conditions": [],
-  "limitations": [],
+  "permissions": [
+    "commercial-use",
+    "modifications",
+    "distribution",
+    "private-use",
+    "data-use",
+    "create-adaptations"
+  ],
+  "conditions": [
+    "attribution",
+    "non-endorsement"
+  ],
+  "limitations": [
+    "liability",
+    "warranty",
+    "no-personal-data-guarantee"
+  ],
   "tags": [
-    "license:government-open-license",
-    "domain:data",
+    "copyleft:none",
     "domain:content",
+    "domain:data",
+    "license:government-open-license",
+    "notes:attribution-required",
     "notes:government-open-license",
-    "notes:attribution-required"
-  ]
+    "region:FR"
+  ],
+  "reasons": {
+    "permissions": {
+      "commercial-use": [
+        "[verbatim] \"à des fins commerciales ou non\"",
+        "[verbatim] \"de l’exploiter à titre commercial\""
+      ],
+      "modifications": [
+        "[verbatim] \"de l’adapter, la modifier, l’extraire et la transformer\""
+      ],
+      "distribution": [
+        "[verbatim] \"de la communiquer, la diffuser, la redistribuer, la publier et la transmettre\""
+      ],
+      "private-use": [
+        "[verbatim] \"à des fins commerciales ou non\""
+      ],
+      "data-use": [
+        "[verbatim] \"libre 'Réutilisation' de l'Information'\"",
+        "[verbatim] \"informations publiques\""
+      ],
+      "create-adaptations": [
+        "[verbatim] \"pour créer des 'Informations dérivées', des produits ou des services\""
+      ]
+    },
+    "conditions": {
+      "attribution": [
+        "[verbatim] \"mentionner la paternité de l'Information' : sa source... et la date de dernière mise à jour\""
+      ],
+      "non-endorsement": [
+        "[verbatim] \"ne doit pas suggérer une quelconque reconnaissance ou caution par le 'Concédant'\""
+      ]
+    },
+    "limitations": {
+      "liability": [
+        "[verbatim] \"Il ne peut être tenu pour responsable de toute perte, préjudice ou dommage\""
+      ],
+      "warranty": [
+        "[verbatim] \"sans autre garantie expresse ou tacite\"",
+        "[verbatim] \"L’absence de défauts ou d’erreurs... n’est pas garantie\""
+      ],
+      "no-personal-data-guarantee": [
+        "[verbatim] \"peut contenir des 'Données à caractère personnel'\"",
+        "[verbatim] \"à condition de respecter le cadre légal relatif à la protection des données\""
+      ]
+    }
+  }
 }

--- a/data/licenses/etalab-2.0.json
+++ b/data/licenses/etalab-2.0.json
@@ -49,11 +49,11 @@
   ],
   "limitations": [
     "liability",
-    "warranty",
-    "no-personal-data-guarantee"
+    "warranty"
   ],
   "tags": [
     "copyleft:none",
+    "copyleft:permissive",
     "domain:content",
     "domain:data",
     "license:government-open-license",
@@ -74,22 +74,23 @@
         "[verbatim] \"de la communiquer, la diffuser, la redistribuer, la publier et la transmettre\""
       ],
       "private-use": [
-        "[verbatim] \"à des fins commerciales ou non\""
+        "[inferred] Broad right of libre \"Réutilisation\" for commercial or non-commercial purposes includes private use"
       ],
       "data-use": [
-        "[verbatim] \"libre 'Réutilisation' de l'Information'\"",
-        "[verbatim] \"informations publiques\""
+        "[verbatim] \"libre « Réutilisation » de l’« Information »\"",
+        "[verbatim] \"informations publiques\"",
+        "[verbatim] \"droit sui generis des producteurs de bases de données\""
       ],
       "create-adaptations": [
-        "[verbatim] \"pour créer des 'Informations dérivées', des produits ou des services\""
+        "[verbatim] \"pour créer des « Informations dérivées », des produits ou des services\""
       ]
     },
     "conditions": {
       "attribution": [
-        "[verbatim] \"mentionner la paternité de l'Information' : sa source... et la date de dernière mise à jour\""
+        "[verbatim] \"mentionner la paternité de l’« Information » : sa source... et la date de dernière mise à jour\""
       ],
       "non-endorsement": [
-        "[verbatim] \"ne doit pas suggérer une quelconque reconnaissance ou caution par le 'Concédant'\""
+        "[verbatim] \"ne doit pas suggérer une quelconque reconnaissance ou caution par le « Concédant »\""
       ]
     },
     "limitations": {
@@ -99,10 +100,6 @@
       "warranty": [
         "[verbatim] \"sans autre garantie expresse ou tacite\"",
         "[verbatim] \"L’absence de défauts ou d’erreurs... n’est pas garantie\""
-      ],
-      "no-personal-data-guarantee": [
-        "[verbatim] \"peut contenir des 'Données à caractère personnel'\"",
-        "[verbatim] \"à condition de respecter le cadre légal relatif à la protection des données\""
       ]
     }
   }


### PR DESCRIPTION
# Description

This pull request updates the metadata for the Etalab 2.0 license in `data/licenses/etalab-2.0.json` to provide a more accurate and comprehensive description of its permissions, conditions, limitations, and tags. The main improvements include explicitly listing the allowed uses and obligations, and refining the categorization tags for better clarity.

**Metadata improvements:**

* Added explicit lists for `permissions` (commercial use, modifications, distribution, private use, data use, creating adaptations), `conditions` (attribution, non-endorsement), and `limitations` (liability, warranty) to clarify what the license allows and requires.
* Expanded and reorganized the `tags` field to better describe the license's characteristics, including its copyleft status, domain, and regional applicability.
* Included a new `reasons` field that provides verbatim and inferred justifications from the license text for each listed permission, condition, and limitation, improving traceability and transparency.