### PR TITLE
lic: update DL-DE-BY-2.0 rules

### DIFF
--- a/data/licenses/DL-DE-BY-2.0.json
+++ b/data/licenses/DL-DE-BY-2.0.json
@@ -23,11 +23,64 @@
     "licenseTextHtml": "\n         <var class=\"optional-license-text\"> DL-DE-&gt;BY-2.0</var>\n         <var class=\"optional-license-text\"> Datenlizenz Deutschland – Namensnennung – Version 2.0</var>\n         \n<ul style=\"list-style:none\">\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (1)</span></var>Jede Nutzung ist unter den Bedingungen dieser „Datenlizenz Deutschland – Namensnennung – Version 2.0&quot; zulässig.\n            <p>Die bereitgestellten Daten und Metadaten dürfen für die kommerzielle und nicht kommerzielle Nutzung insbesondere</p>\n\n<ul style=\"list-style:none\">\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 1.</span></var>vervielfältigt, ausgedruckt, präsentiert, verändert, bearbeitet sowie an Dritte übermittelt werden;</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 2.</span></var>mit eigenen Daten und Daten Anderer zusammengeführt und zu selbständigen neuen Datensätzen verbunden werden;</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 3.</span></var>in interne und externe Geschäftsprozesse, Produkte und Anwendungen in öffentlichen und nicht öffentlichen elektronischen Netzwerken eingebunden werden.</li>\n            \n</ul></li>\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (2)</span></var>Bei der Nutzung ist sicherzustellen, dass folgende Angaben als Quellenvermerk enthalten sind:\n            \n<ul style=\"list-style:none\">\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 1.</span></var>Bezeichnung des Bereitstellers nach dessen Maßgabe,</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 2.</span></var>der Vermerk „Datenlizenz Deutschland – Namensnennung – Version 2.0&quot; oder „dl-de/by-2-0&quot; mit Verweis auf den Lizenztext unter www.govdata.de/dl-de/by-2-0 sowie</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 3.</span></var>einen Verweis auf den Datensatz (URI).</li>\n            \n</ul>\n            <p>Dies gilt nur soweit die datenhaltende Stelle die Angaben 1. bis 3. zum Quellenvermerk bereitstellt.</p>\n</li>\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (3)</span></var>Veränderungen, Bearbeitungen, neue Gestaltungen oder sonstige Abwandlungen sind im Quellenvermerk mit dem Hinweis zu versehen, dass die Daten geändert wurden.</li>\n         \n</ul>\n         <var class=\"optional-license-text\"> Data licence Germany – attribution – version 2.0</var>\n         \n<ul style=\"list-style:none\">\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (1)</span></var>Any use will be permitted provided it fulfils the requirements of this &quot;Data licence Germany – attribution – Version 2.0&quot;.\n            <p>The data and meta-data provided may, for commercial and non-commercial use, in particular</p>\n\n<ul style=\"list-style:none\">\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 1.</span></var>be copied, printed, presented, altered, processed and transmitted to third parties;</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 2.</span></var>be merged with own data and with the data of others and be combined to form new and independent datasets;</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 3.</span></var>be integrated in internal and external business processes, products and applications in public and non-public electronic networks.</li>\n            \n</ul></li>\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (2)</span></var>The user must ensure that the source note contains the following information:\n            \n<ul style=\"list-style:none\">\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 1.</span></var>the name of the provider,</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 2.</span></var>the annotation &quot;Data licence Germany – attribution – Version 2.0&quot; or &quot;dl-de/by-2-0&quot; referring to the licence text available at www.govdata.de/dl-de/by-2-0, and</li>\n               \n<li>\n               <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> 3.</span></var>a reference to the dataset (URI).</li>\n            \n</ul>\n            <p>This applies only if the entity keeping the data provides the pieces of information 1-3 for the source note.</p>\n</li>\n            \n<li>\n            <var class=\"replaceable-license-text\"><span title=\"can be replaced with the pattern .{0,20}\"> (3)</span></var>Changes, editing, new designs or other amendments must be marked as such in the source note.</li>\n         \n</ul>\n         <div class=\"optional-license-text\"> \n            <p>URL: http://www.govdata.de/dl-de/by-2-0</p>\n\n         </div>\n      "
   },
   "categorized": false,
-  "permissions": [],
-  "conditions": [],
+  "permissions": [
+    "commercial-use",
+    "modifications",
+    "distribution",
+    "private-use",
+    "data-use",
+    "create-adaptations"
+  ],
+  "conditions": [
+    "attribution",
+    "mark-changes",
+    "license-linking"
+  ],
   "limitations": [],
   "tags": [
+    "copyleft:none",
+    "domain:data",
+    "domain:software",
+    "license:government-open-license",
     "license:open-source",
-    "domain:software"
-  ]
+    "notes:attribution-required",
+    "notes:government-open-license",
+    "region:DE"
+  ],
+  "reasons": {
+    "permissions": {
+      "commercial-use": [
+        "[verbatim] \"The data and meta-data provided may, for commercial and non-commercial use\""
+      ],
+      "modifications": [
+        "[verbatim] \"be copied, printed, presented, altered, processed\""
+      ],
+      "distribution": [
+        "[verbatim] \"transmitted to third parties\""
+      ],
+      "private-use": [
+        "[verbatim] \"be integrated in internal... products and applications in... non-public electronic networks\""
+      ],
+      "data-use": [
+        "[verbatim] \"The data and meta-data provided may... be copied, printed, presented\""
+      ],
+      "create-adaptations": [
+        "[verbatim] \"be merged with own data and with the data of others and be combined to form new and independent datasets\""
+      ]
+    },
+    "conditions": {
+      "attribution": [
+        "[verbatim] \"The user must ensure that the source note contains... the name of the provider\"",
+        "[verbatim] \"a reference to the dataset (URI)\""
+      ],
+      "mark-changes": [
+        "[verbatim] \"Changes, editing, new designs or other amendments must be marked as such in the source note.\""
+      ],
+      "license-linking": [
+        "[verbatim] \"the annotation \\\"Data licence Germany – attribution – Version 2.0\\\"... referring to the licence text\"",
+        "[verbatim] \"available at www.govdata.de/dl-de/by-2-0\""
+      ]
+    },
+    "limitations": {}
+  }
 }


### PR DESCRIPTION
# Description
This pull request updates the metadata for the `DL-DE-BY-2.0` license in `data/licenses/DL-DE-BY-2.0.json` to provide a more detailed and accurate description of its permissions, conditions, and tags. The changes clarify what is allowed under the license and the requirements for using licensed data.

Key improvements to license metadata:

**Permissions and Conditions:**

* Added explicit permissions such as `commercial-use`, `modifications`, `distribution`, `private-use`, `data-use`, and `create-adaptations` to clearly state what users are allowed to do with the data.
* Added conditions including `attribution`, `mark-changes`, and `license-linking` to specify the requirements users must follow when using or modifying the data.

**Tags and Classification:**

* Expanded the list of tags to include license characteristics (e.g., `copyleft:none`, `license:government-open-license`), usage notes (e.g., `notes:attribution-required`, `notes:government-open-license`), and region (`region:DE`).

**Rationale and Documentation:**

* Introduced a `reasons` section that provides verbatim excerpts from the license text to justify each permission and condition, improving traceability and transparency.