### PR TITLE
lic: update OGL-UK-3.0 rules

### DIFF
--- a/data/licenses/OGL-UK-3.0.json
+++ b/data/licenses/OGL-UK-3.0.json
@@ -25,14 +25,91 @@
     "licenseTextHtml": "\n            <var class=\"optional-license-text\"> Open Government Licence v3.0</var>\n            <p>You are encouraged to use and re-use the Information that is available under this licence freely and flexibly, with only a few conditions.</p>\n\n            <p>Using Information under this licence</p>\n\n            <p>Use of copyright and database right material expressly made available under this licence (the &apos;Information&apos;) indicates your acceptance of the terms and conditions below.</p>\n\n            <p>The Licensor grants you a worldwide, royalty-free, perpetual, non-exclusive licence to use the Information subject to the conditions below.</p>\n\n            <p>This licence does not affect your freedom under fair dealing or fair use or any other copyright or database right exceptions and limitations.</p>\n\n            <p>You are free to:</p>\n\n<ul style=\"list-style:none\">\n                \n<li>copy, publish, distribute and transmit the Information;</li>\n                \n<li>adapt the Information;</li>\n                \n<li>exploit the Information commercially and non-commercially for example, by combining it with other Information, or by including it in your own product or application.</li>\n            \n</ul>\n            <p>You must (where you do any of the above):</p>\n\n<ul style=\"list-style:none\">\n                \n<li>acknowledge the source of the Information in your product or application by including or linking to any attribution statement specified by the Information Provider(s) and, where possible, provide a link to this licence;\n                    <p> If the Information Provider does not provide a specific attribution statement, you must use the following:\n                        <br />\n   Contains public sector information licensed under the Open Government Licence v3.0.\n                    </p>\n\n                    <p>If you are using Information from several Information Providers and listing multiple attributions is not practical in your product or application, you may include a URI or hyperlink to a resource that contains the required attribution statements.</p>\n\n                    <p>These are important conditions of this licence and if you fail to comply with them the rights granted to you under this licence, or any similar licence granted by the Licensor, will end automatically.</p>\n\n                </li>\n            \n</ul>\n            <p>Exemptions</p>\n\n            <p>This licence does not cover:</p>\n\n<ul style=\"list-style:none\">\n                \n<li>personal data in the Information;</li>\n                \n<li>Information that has not been accessed by way of publication or disclosure under information access legislation (including the Freedom of Information Acts for the UK and Scotland) by or with the consent of the Information Provider;</li>\n                \n<li>departmental or public sector organisation logos, crests and the Royal Arms except where they form an integral part of a document or dataset;</li>\n                \n<li>military insignia;</li>\n                \n<li>third party rights the Information Provider is not authorised to license;</li>\n                \n<li>other intellectual property rights, including patents, trade marks, and design rights; and</li>\n                \n<li>identity documents such as the British Passport</li>\n            \n</ul>\n            <p>Non-endorsement</p>\n\n            <p>This licence does not grant you any right to use the Information in a way that suggests any official status or that the Information Provider and/or Licensor endorse you or your use of the Information.</p>\n\n            <p>No warranty</p>\n\n            <p>The Information is licensed &apos;as is&apos; and the Information Provider and/or Licensor excludes all representations, warranties, obligations and liabilities in relation to the Information to the maximum extent permitted by law.</p>\n\n            <p>The Information Provider and/or Licensor are not liable for any errors or omissions in the Information and shall not be liable for any loss, injury or damage of any kind caused by its use. The Information Provider does not guarantee the continued supply of the Information.</p>\n\n            <p>Governing Law</p>\n\n            <p>This licence is governed by the laws of the jurisdiction in which the Information Provider has its principal place of business, unless otherwise specified by the Information Provider.</p>\n\n            <p>Definitions</p>\n\n            <p>In this licence, the terms below have the following meanings:</p>\n\n<ul style=\"list-style:none\">\n                \n<li>&apos;Information&apos; means information protected by copyright or by database right (for example, literary and artistic works, content, data and source code) offered for use under the terms of this licence.</li>\n                \n<li>&apos;Information Provider&apos; means the person or organisation providing the Information under this licence.</li>\n                \n<li>&apos;Licensor&apos; means any Information Provider which has the authority to offer Information under the terms of this licence or the Keeper of Public Records, who has the authority to offer Information subject to Crown copyright and Crown database rights and Information subject to copyright and database right that has been assigned to or acquired by the Crown, under the terms of this licence.</li>\n                \n<li>&apos;Use&apos; means doing any act which is restricted by copyright or database right, whether in the original medium or in any other medium, and includes without limitation distributing, copying, adapting, modifying as may be technically necessary to use it in a different mode or format.</li>\n                \n<li>&apos;You&apos;, &apos;you&apos; and &apos;your&apos; means the natural or legal person, or body of persons corporate or incorporate, acquiring rights in the Information (whether the Information is obtained directly from the Licensor or otherwise) under this licence.</li>\n            \n</ul>\n            <p>About the Open Government Licence</p>\n\n            <p>The National Archives has developed this licence as a tool to enable Information Providers in the public sector to license the use and re-use of their Information under a common open licence. The National Archives invites public sector bodies owning their own copyright and database rights to permit the use of their Information under this licence.</p>\n\n            <p>The Keeper of the Public Records has authority to license Information subject to copyright and database right owned by the Crown. The extent of the offer to license this Information under the terms of this licence is set out in the UK Government Licensing Framework.</p>\n\n            <p>This is version 3.0 of the Open Government Licence. The National Archives may, from time to time, issue new versions of the Open Government Licence. If you are already using Information under a previous version of the Open Government Licence, the terms of that licence will continue to apply.</p>\n\n            <p>These terms are compatible with the Creative Commons Attribution License 4.0 and the Open Data Commons Attribution License, both of which license copyright and database rights. This means that when the Information is adapted and licensed under either of those licences, you automatically satisfy the conditions of the OGL when you comply with the other licence. The OGLv3.0 is Open Definition compliant.</p>\n\n            <p>Further context, best practice and guidance can be found in the UK Government Licensing Framework section on The National Archives website.</p>\n\n        "
   },
   "categorized": false,
-  "permissions": [],
-  "conditions": [],
-  "limitations": [],
+  "permissions": [
+    "commercial-use",
+    "modifications",
+    "distribution",
+    "private-use",
+    "data-use",
+    "create-adaptations"
+  ],
+  "conditions": [
+    "attribution",
+    "non-endorsement",
+    "license-linking"
+  ],
+  "limitations": [
+    "trademark-use",
+    "patent-use",
+    "liability",
+    "warranty",
+    "no-personal-data-guarantee"
+  ],
   "tags": [
-    "license:government-open-license",
-    "domain:data",
+    "copyleft:none",
     "domain:content",
+    "domain:data",
+    "domain:mixed",
+    "license:government-open-license",
+    "notes:attribution-required",
     "notes:government-open-license",
-    "notes:attribution-required"
-  ]
+    "region:UK"
+  ],
+  "reasons": {
+    "permissions": {
+      "commercial-use": [
+        "[verbatim] You are free to \"exploit the Information commercially and non-commercially\""
+      ],
+      "modifications": [
+        "[verbatim] You are free to \"adapt the Information;\"",
+        "[verbatim] \"Use\" includes \"adapting, modifying as may be technically necessary\""
+      ],
+      "distribution": [
+        "[verbatim] You are free to \"copy, publish, distribute and transmit the Information;\""
+      ],
+      "private-use": [
+        "[inferred] Broad licence to \"use the Information\" with no clause excluding private use permits private use"
+      ],
+      "data-use": [
+        "[verbatim] \"Information\" means information protected by copyright or by database right",
+        "[verbatim] \"Information\" includes \"content, data and source code\""
+      ],
+      "create-adaptations": [
+        "[verbatim] You are free to \"adapt the Information;\""
+      ]
+    },
+    "conditions": {
+      "attribution": [
+        "[verbatim] You must \"acknowledge the source... by including or linking to any attribution statement\"",
+        "[verbatim] If none is provided, \"you must use\" the stated OGL attribution notice"
+      ],
+      "non-endorsement": [
+        "[verbatim] No right to use the Information in a way that \"suggests any official status\"",
+        "[verbatim] No right to suggest the provider or licensor \"endorse you or your use\""
+      ],
+      "license-linking": [
+        "[verbatim] You must, \"where possible, provide a link to this licence;\""
+      ]
+    },
+    "limitations": {
+      "trademark-use": [
+        "[verbatim] This licence does not cover \"trade marks\"",
+        "[verbatim] This licence does not cover \"logos, crests and the Royal Arms\""
+      ],
+      "patent-use": [
+        "[verbatim] This licence does not cover \"other intellectual property rights, including patents\""
+      ],
+      "liability": [
+        "[verbatim] Licensor \"shall not be liable for any loss, injury or damage of any kind caused by its use\"",
+        "[verbatim] Licensor \"are not liable for any errors or omissions in the Information\""
+      ],
+      "warranty": [
+        "[verbatim] The Information is licensed \"as is\"",
+        "[verbatim] Licensor \"excludes all representations, warranties, obligations and liabilities\""
+      ],
+      "no-personal-data-guarantee": [
+        "[verbatim] This licence does not cover \"personal data in the Information;\""
+      ]
+    }
+  }
 }


### PR DESCRIPTION
# Description
This pull request updates the metadata for the Open Government Licence v3.0 (`OGL-UK-3.0.json`) to provide a more detailed and structured breakdown of the license's permissions, conditions, and limitations. It also enhances the tagging and adds explicit reasoning for each permission, condition, and limitation, improving clarity and machine readability.

Key improvements include:

**Structured License Metadata:**

- Added explicit lists for `permissions`, `conditions`, and `limitations`, detailing what is allowed, required, and restricted under the license.
- Included a new `reasons` section, providing verbatim or inferred justifications from the license text for each permission, condition, and limitation.

**Tagging Enhancements:**

- Expanded and reorganized the `tags` array to include additional descriptors such as `copyleft:none`, `domain:mixed`, `notes:attribution-required`, and `region:UK` for improved categorization and discoverability.
